### PR TITLE
Remove user-data-dir, after launcher exited.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -93,10 +93,11 @@ func Example_search() {
 func Example_headless_with_debug() {
 	// Headless runs the browser on foreground, you can also use env "rod=show"
 	// Devtools opens the tab in each new tab opened automatically
-	url := launcher.New().
+	l := launcher.New().
 		Headless(false).
-		Devtools(true).
-		Launch()
+		Devtools(true)
+	defer l.Cleanup()
+	url := l.Launch()
 
 	// Trace shows verbose debug information for each action executed
 	// Slowmotion is a debug related function that waits 2 seconds between

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -347,6 +348,17 @@ func (l *Launcher) PID() int {
 	return l.pid
 }
 
+// Cleanup wait until the Browser exits and release related resources
+func (l *Launcher) Cleanup() {
+	<-l.exit
+	if _, has := l.Get("keep-user-data-dir"); !has {
+		dir, _ := l.Get("user-data-dir")
+		fmt.Println(utils.C("Remove", "cyan"), dir)
+
+		_ = os.RemoveAll(dir)
+	}
+}
+
 func (l *Launcher) kill() {
 	p, err := os.FindProcess(l.pid)
 	if err == nil {
@@ -401,6 +413,12 @@ func (l *Launcher) getURL() (u string, err error) {
 			utils.E(errors.New("[launcher] Failed to get the debug url: " + out))
 		}
 	}
+}
+
+// KeepUserDataDir after browser is closed. By default user-data-dir will be removed.
+func (l *Launcher) KeepUserDataDir() *Launcher {
+	l.Set("keep-user-data-dir")
+	return l
 }
 
 // GetWebSocketDebuggerURL from browser remote url

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -353,7 +353,9 @@ func (l *Launcher) Cleanup() {
 	<-l.exit
 	if _, has := l.Get("keep-user-data-dir"); !has {
 		dir, _ := l.Get("user-data-dir")
-		fmt.Println(utils.C("Remove", "cyan"), dir)
+		if l.log != nil {
+			l.log(fmt.Sprintln(utils.C("Remove", "cyan"), dir))
+		}
 
 		_ = os.RemoveAll(dir)
 	}

--- a/lib/launcher/private_test.go
+++ b/lib/launcher/private_test.go
@@ -85,10 +85,6 @@ func TestRemoteLaunch(t *testing.T) {
 
 	kit.Sleep(1)
 	assert.NoDirExists(t, dir)
-
-	assert.Panics(t, func() {
-		New().KeepUserDataDir()
-	})
 }
 
 func TestLaunchErr(t *testing.T) {


### PR DESCRIPTION
Fix #181 

```go
package main

import (
	"fmt"
	"os"

	"github.com/go-rod/rod"
	"github.com/go-rod/rod/lib/launcher"
)

const tempdir = "tempdir"

func main() {
	_, err := os.Stat(tempdir)
	fmt.Println(err)
	demo()

	_, err = os.Stat(tempdir)
	fmt.Println(err)
}

func demo() {
	launcher := launcher.New().UserDataDir(tempdir)
	defer launcher.Cleanup()
	url := launcher.Launch()

	browser := rod.New().ControlURL(url).Connect().Trace(true)
	defer browser.Close()

	page := browser.Page("https://google.com")
	defer page.Close()
	page.WaitLoad()
}


```

Output: 
```
stat tempdir: no such file or directory
Remove /home/luap/lakbot/test/tempdir
stat tempdir: no such file or directory
```

I don't like the Cleanup function, but else the program exits before waiting until the browser process exited, maybe someone has an idea how to work around this.