### PR TITLE
GetDownloadFile for browser level

### DIFF
--- a/hijack.go
+++ b/hijack.go
@@ -369,6 +369,66 @@ func (ctx *HijackResponse) Fail(reason proto.NetworkErrorReason) *HijackResponse
 	return ctx
 }
 
+func (b *Browser) GetDownloadFile(pattern string, client *http.Client) func() (http.Header, []byte, error) {
+	enable := b.DisableDomain("", &proto.FetchEnable{})
+
+	_ = proto.BrowserSetDownloadBehavior{
+		Behavior:         proto.BrowserSetDownloadBehaviorBehaviorDeny,
+		BrowserContextID: b.BrowserContextID,
+	}.Call(b)
+
+	r := b.HijackRequests()
+
+	ctx, cancel := context.WithCancel(b.GetContext())
+	downloading := &proto.PageDownloadWillBegin{}
+	waitDownload := b.Context(ctx).WaitEvent(downloading)
+
+	return func() (http.Header, []byte, error) {
+		defer enable()
+		defer cancel()
+
+		defer func() {
+			_ = proto.BrowserSetDownloadBehavior{
+				Behavior:         proto.BrowserSetDownloadBehaviorBehaviorDefault,
+				BrowserContextID: b.BrowserContextID,
+			}.Call(b)
+		}()
+
+		var body []byte
+		var header http.Header
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+
+		var err error
+		err = r.Add(pattern, "", func(ctx *Hijack) {
+			defer wg.Done()
+
+			ctx.Skip = true
+
+			err = ctx.LoadResponse(client, true)
+			if err != nil {
+				return
+			}
+
+			header = ctx.Response.Headers()
+			body = ctx.Response.Payload().Body
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		go r.Run()
+		go func() {
+			waitDownload()
+		}()
+
+		wg.Wait()
+		r.MustStop()
+
+		return header, body, nil
+	}
+}
+
 // GetDownloadFile of the next download url that matches the pattern, returns the file content.
 // The handler will be used once and removed.
 func (p *Page) GetDownloadFile(pattern string, resourceType proto.NetworkResourceType, client *http.Client) func() (http.Header, []byte, error) {

--- a/must.go
+++ b/must.go
@@ -282,6 +282,16 @@ func (p *Page) MustGetDownloadFile(pattern string) func() []byte {
 	}
 }
 
+// MustGetDownloadFile is similar to GetDownloadFile
+func (b *Browser) MustGetDownloadFile(pattern string) func() []byte {
+	wait := b.GetDownloadFile(pattern, http.DefaultClient)
+	return func() []byte {
+		_, body, err := wait()
+		utils.E(err)
+		return body
+	}
+}
+
 // MustWaitOpen is similar to WaitOpen
 func (p *Page) MustWaitOpen() (wait func() (newPage *Page)) {
 	w := p.WaitOpen()


### PR DESCRIPTION
Fix #245

Description for the changes.
Browser.GetDownloadFile for window.open("url") capture.