### PR TITLE
Also detect Podman in rod-launcher

### DIFF
--- a/lib/launcher/utils.go
+++ b/lib/launcher/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-rod/rod/lib/utils"
 )
 
-var isInDocker = utils.FileExists("/.dockerenv")
+var isInDocker = utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")
 
 type progresser struct {
 	size   int


### PR DESCRIPTION
[Podman](https://podman.io/) is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System, which can be treated more or less as a drop-in replacement for Docker with several caveats, e.g. it uses `/.containerenv` instead of `/.dockerenv`.

