### PR TITLE
Add browser flag to testing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,6 +39,15 @@ rod=show,trace,slow=2s go test -v -run /Click
 
 Check type `defaults.ResetWithEnv` for how it works.
 
+### Specify browser binary
+
+To use a locally installed browser, instead of downloading the latest version of chromium every time while running tests, use the `--browser-bin=<command to launch browser>` flag.
+
+For example:
+```bash
+go test -v --browser-bin=google-chrome
+```
+
 ### Lint project
 
 ```bash

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,11 +41,11 @@ Check type `defaults.ResetWithEnv` for how it works.
 
 ### Specify browser binary
 
-To use a locally installed browser, instead of downloading the latest version of chromium every time while running tests, use the `--browser-bin=<command to launch browser>` flag.
+You can use the `-browser-bin` flag to specify a custom browser executable path:
 
 For example:
 ```bash
-go test -v --browser-bin=google-chrome
+go test -v --browser-bin=/path/to/browser
 ```
 
 ### Lint project

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Check type `defaults.ResetWithEnv` for how it works.
 You can use the `-browser-bin` flag to specify a custom browser executable path:
 
 For example:
+
 ```bash
 go test -v --browser-bin=/path/to/browser
 ```

--- a/setup_test.go
+++ b/setup_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 var TimeoutEach = flag.Duration("timeout-each", time.Minute, "timeout for each test")
+var BrowserBin = flag.String("browser-bin", "", "browser binary to use")
 
 var LogDir = slash(fmt.Sprintf("tmp/cdp-log/%s", time.Now().Format("2006-01-02_15-04-05")))
 
@@ -83,17 +84,15 @@ func newTesterPool(t *testing.T) TesterPool {
 
 // new tester
 func (cp TesterPool) new() *T {
-	bin := ""
-
-	if !(utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")) {
+	if !(*BrowserBin != "" || utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")) {
 		b := launcher.NewBrowser()
 		b.ExecSearchMap = make(map[string][]string)
 		var err error
-		bin, err = b.Get()
+		*BrowserBin, err = b.Get()
 		utils.E(err)
 	}
 
-	u := launcher.New().Bin(bin).MustLaunch()
+	u := launcher.New().Bin(*BrowserBin).MustLaunch()
 
 	mc := newMockClient(u)
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -85,7 +85,8 @@ func newTesterPool(t *testing.T) TesterPool {
 // new tester
 func (cp TesterPool) new() *T {
 	bin := *BrowserBin
-	if !(bin != "" || utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")) {
+	const notInContainer = !(utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv"))
+	if bin == "" && notInContainer {
 		b := launcher.NewBrowser()
 		b.ExecSearchMap = make(map[string][]string)
 		var err error

--- a/setup_test.go
+++ b/setup_test.go
@@ -84,15 +84,16 @@ func newTesterPool(t *testing.T) TesterPool {
 
 // new tester
 func (cp TesterPool) new() *T {
-	if !(*BrowserBin != "" || utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")) {
+	bin := *BrowserBin
+	if !(bin != "" || utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv")) {
 		b := launcher.NewBrowser()
 		b.ExecSearchMap = make(map[string][]string)
 		var err error
-		*BrowserBin, err = b.Get()
+		bin, err = b.Get()
 		utils.E(err)
 	}
 
-	u := launcher.New().Bin(*BrowserBin).MustLaunch()
+	u := launcher.New().Bin(bin).MustLaunch()
 
 	mc := newMockClient(u)
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -85,7 +85,7 @@ func newTesterPool(t *testing.T) TesterPool {
 // new tester
 func (cp TesterPool) new() *T {
 	bin := *BrowserBin
-	const notInContainer = !(utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv"))
+	notInContainer := !(utils.FileExists("/.dockerenv") || utils.FileExists("/.containerenv"))
 	if bin == "" && notInContainer {
 		b := launcher.NewBrowser()
 		b.ExecSearchMap = make(map[string][]string)


### PR DESCRIPTION
The reason this has been proposed is as follows:

- Many times, I may not wish to download the latest version of chromium, due to bandwidth restrictions.
- I may wish to test the library on a particular version of the browser of my choosing.

For these reasons, the PR provides a flag to specify while testing:
```bash
go test --browser-bin=<command to launch browser>
```
to set the browser to use to run tests. 