### PR TITLE
add method MoveMouseOut to the element

### DIFF
--- a/element.go
+++ b/element.go
@@ -716,6 +716,7 @@ func (el *Element) id() proto.RuntimeRemoteObjectID {
 	return el.Object.ObjectID
 }
 
+// MoveMouseOut Move the mouse out of the current element
 func (el *Element) MoveMouseOut() error {
 	shape, err := el.Shape()
 	if err != nil {

--- a/element.go
+++ b/element.go
@@ -715,3 +715,12 @@ func (el *Element) Equal(elm *Element) (bool, error) {
 func (el *Element) id() proto.RuntimeRemoteObjectID {
 	return el.Object.ObjectID
 }
+
+func (el *Element) MoveMouseOut() error {
+	shape, err := el.Shape()
+	if err != nil {
+		return err
+	}
+	box := shape.Box()
+	return el.page.Mouse.Move(box.X+box.Width, box.Y, 1)
+}


### PR DESCRIPTION
When you use the Hover method on the element, then you can use the MoveMouseOut method to move the mouse out of the element