### PR TITLE
setup process group for windows

### DIFF
--- a/lib/launcher/os_windows.go
+++ b/lib/launcher/os_windows.go
@@ -2,10 +2,27 @@
 
 package launcher
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+)
 
 func killGroup(pid int) {
+	terminateProcess(pid)
 }
 
 func (l *Launcher) osSetupCmd(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+func terminateProcess(pid int) {
+	handle, err := syscall.OpenProcess(syscall.PROCESS_TERMINATE, true, uint32(pid))
+	if err != nil {
+		return
+	}
+
+	syscall.TerminateProcess(handle, 0)
+	syscall.CloseHandle(handle)
 }


### PR DESCRIPTION
Sometimes the launcher and browser were leaving processes open. Use
process groups, similarly to unix.
