### PR TITLE
Add modifiers to mouse UP event #500

### DIFF
--- a/input.go
+++ b/input.go
@@ -237,6 +237,7 @@ func (m *Mouse) Up(button proto.InputMouseButton, clicks int) error {
 		Button:     button,
 		Buttons:    buttons,
 		ClickCount: clicks,
+		Modifiers:  m.page.Keyboard.getModifiers(),
 		X:          m.x,
 		Y:          m.y,
 	}.Call(m.page)


### PR DESCRIPTION
As raised in issue #500, keyboard modifiers are not working while making mouse clicks.

For eg. Manual `Alt+Click` an anchor, downloads a PDF file in Chrome browser. But as `Alt` keyboard modifier is not working in ROD, `Alt+Click` an anchor is opening the PDF in Chrome PDF viewer.

The problem is, where as `Modifiers:  m.page.Keyboard.getModifiers()` is provided to mouse DOWN event, it is not provided to mouse UP event.

Keyboard modifiers are working after the `Modifiers:  m.page.Keyboard.getModifiers()` is provided to mouse UP event as well.

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
I ran the above successfully.
