### PR TITLE
add page.SetDocumentContent helper

### DIFF
--- a/must.go
+++ b/must.go
@@ -818,6 +818,12 @@ func (el *Element) MustSetFiles(paths ...string) *Element {
 	return el
 }
 
+// MustSetDocumentContent is similar to Page.SetDocumentContent
+func (p *Page) MustSetDocumentContent(html string) *Page {
+	p.e(p.SetDocumentContent(html))
+	return p
+}
+
 // MustText is similar to Element.Text
 func (el *Element) MustText() string {
 	s, err := el.Text()

--- a/page.go
+++ b/page.go
@@ -254,6 +254,20 @@ func (p *Page) SetViewport(params *proto.EmulationSetDeviceMetricsOverride) erro
 	return params.Call(p)
 }
 
+// SetDocumentContent sets the page document html content
+func (p *Page) SetDocumentContent(html string) error {
+	err := proto.PageSetDocumentContent{
+		FrameID: p.FrameID,
+		HTML:    html,
+	}.Call(p)
+
+	if err != nil {
+		return fmt.Errorf("could not set the page document html content: %w", err)
+	}
+
+	return nil
+}
+
 // Emulate the device, such as iPhone9. If device is devices.Clear, it will clear the override.
 func (p *Page) Emulate(device devices.Device) error {
 	err := p.SetViewport(device.MetricsEmulation())

--- a/page.go
+++ b/page.go
@@ -256,16 +256,10 @@ func (p *Page) SetViewport(params *proto.EmulationSetDeviceMetricsOverride) erro
 
 // SetDocumentContent sets the page document html content
 func (p *Page) SetDocumentContent(html string) error {
-	err := proto.PageSetDocumentContent{
+	return proto.PageSetDocumentContent{
 		FrameID: p.FrameID,
 		HTML:    html,
 	}.Call(p)
-
-	if err != nil {
-		return fmt.Errorf("could not set the page document html content: %w", err)
-	}
-
-	return nil
 }
 
 // Emulate the device, such as iPhone9. If device is devices.Clear, it will clear the override.

--- a/page_test.go
+++ b/page_test.go
@@ -215,6 +215,59 @@ func (t T) SetViewport() {
 	t.Neq(int(317), res.Get("0").Int())
 }
 
+func (t T) SetDocumentContent() {
+	page := t.newPage(t.blank())
+
+	doctype := "<!DOCTYPE html>"
+	html4StrictDoctype := `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">`
+	html4LooseDoctype := `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">`
+	xhtml11Doctype := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">`
+
+	exampleWithHTML4StrictDoctype := html4StrictDoctype + "<html><head></head><body><div>test</div></body></html>"
+	page.MustSetDocumentContent(exampleWithHTML4StrictDoctype)
+	exp1 := page.MustEval(`() => new XMLSerializer().serializeToString(document)`).Str()
+	t.Eq(exp1, `<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body><div>test</div></body></html>`)
+	t.Eq(page.MustElement("html").MustHTML(), "<html><head></head><body><div>test</div></body></html>")
+	t.Eq(page.MustElement("head").MustText(), "")
+
+	exampleWithHTML4LooseDoctype := html4LooseDoctype + "<html><head></head><body><div>test</div></body></html>"
+	page.MustSetDocumentContent(exampleWithHTML4LooseDoctype)
+	exp2 := page.MustEval(`() => new XMLSerializer().serializeToString(document)`).Str()
+	t.Eq(exp2, `<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body><div>test</div></body></html>`)
+	t.Eq(page.MustElement("html").MustHTML(), "<html><head></head><body><div>test</div></body></html>")
+	t.Eq(page.MustElement("head").MustText(), "")
+
+	exampleWithXHTMLDoctype := xhtml11Doctype + "<html><head></head><body><div>test</div></body></html>"
+	page.MustSetDocumentContent(exampleWithXHTMLDoctype)
+	exp3 := page.MustEval(`() => new XMLSerializer().serializeToString(document)`).Str()
+	t.Eq(exp3, `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body><div>test</div></body></html>`)
+	t.Eq(page.MustElement("html").MustHTML(), "<html><head></head><body><div>test</div></body></html>")
+	t.Eq(page.MustElement("head").MustText(), "")
+
+	exampleWithHTML5Doctype := doctype + "<html><head></head><body><div>test</div></body></html>"
+	page.MustSetDocumentContent(exampleWithHTML5Doctype)
+	exp4 := page.MustEval(`() => new XMLSerializer().serializeToString(document)`).Str()
+	t.Eq(exp4, `<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body><div>test</div></body></html>`)
+	t.Eq(page.MustElement("html").MustHTML(), "<html><head></head><body><div>test</div></body></html>")
+	t.Eq(page.MustElement("head").MustText(), "")
+
+	exampleWithoutDoctype := "<html><head></head><body><div>test</div></body></html>"
+	page.MustSetDocumentContent(exampleWithoutDoctype)
+	t.Eq(page.MustElement("html").MustHTML(), "<html><head></head><body><div>test</div></body></html>")
+
+	exampleBasic := doctype + "<div>test</div>"
+	page.MustSetDocumentContent(exampleBasic)
+	t.Eq(page.MustElement("div").MustText(), "test")
+
+	exampleWithTrickyContent := "<div>test</div>\x7F"
+	page.MustSetDocumentContent(exampleWithTrickyContent)
+	t.Eq(page.MustElement("div").MustText(), "test")
+
+	exampleWithEmoji := "<div>💪</div>"
+	page.MustSetDocumentContent(exampleWithEmoji)
+	t.Eq(page.MustElement("div").MustText(), "💪")
+}
+
 func (t T) EmulateDevice() {
 	page := t.newPage(t.blank())
 	page.MustEmulate(devices.IPhone6or7or8)


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
Hi, i added this small helper - page.SetDocumentHelper which sets the html string as it's content.
I added few tests, not sure if i am missing something important there, i don't even know what i should test other than this.
Btw, should it take frameId also as argument? It would be bit more verbose but maybe someone has multiple pages and it could make sense in that context?