### PR TITLE
Add host Playwright to support linux arm64 download

### DIFF
--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -31,6 +31,7 @@ var hostConf = map[string]struct {
 	"darwin_amd64":  {"Mac", "chrome-mac.zip"},
 	"darwin_arm64":  {"Mac_Arm", "chrome-mac.zip"},
 	"linux_amd64":   {"Linux_x64", "chrome-linux.zip"},
+	"linux_arm64":   {"chromium", "chromium-linux-arm64.zip"},
 	"windows_386":   {"Win", "chrome-win.zip"},
 	"windows_amd64": {"Win_x64", "chrome-win.zip"},
 }[runtime.GOOS+"_"+runtime.GOARCH]

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -115,6 +116,7 @@ func (lc *Browser) Download() (err error) {
 
 	u, err := lc.fastestHost()
 	utils.E(err)
+	utils.E(os.RemoveAll(lc.Destination()))
 	return lc.download(lc.Context, u)
 }
 
@@ -224,7 +226,16 @@ func (lc *Browser) MustGet() string {
 // Exists returns true if the browser executable path exists.
 func (lc *Browser) Exists() bool {
 	_, err := os.Stat(lc.Destination())
-	return err == nil
+	if err != nil {
+		return false
+	}
+
+	cmd := exec.Command(lc.Destination(), "--version")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return regexp.MustCompile(`\d+.\d+.\d+.\d+`).Match(b)
 }
 
 // LookPath searches for the browser executable from often used paths on current operating system.

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -55,6 +55,16 @@ func HostNPM(revision int) string {
 	)
 }
 
+// HostPlaywright to download browser
+func HostPlaywright(revision int) string {
+	return fmt.Sprintf(
+		"https://playwright.azureedge.net/builds/%s/%d/%s",
+		hostConf.urlPrefix,
+		revision,
+		hostConf.zipName,
+	)
+}
+
 // DefaultBrowserDir for downloaded browser. For unix is "$HOME/.cache/rod/browser",
 // for Windows it's "%APPDATA%\rod\browser"
 var DefaultBrowserDir = filepath.Join(map[string]string{
@@ -88,7 +98,7 @@ func NewBrowser() *Browser {
 	return &Browser{
 		Context:  context.Background(),
 		Revision: DefaultRevision,
-		Hosts:    []Host{HostGoogle, HostNPM},
+		Hosts:    []Host{HostGoogle, HostNPM, HostPlaywright},
 		Dir:      DefaultBrowserDir,
 		Logger:   os.Stdout,
 		LockPort: defaults.LockPort,

--- a/lib/launcher/launcher_test.go
+++ b/lib/launcher/launcher_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-rod/rod/lib/defaults"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/launcher/flags"
+	"github.com/go-rod/rod/lib/utils"
 	"github.com/ysmood/got"
 )
 
@@ -223,4 +224,17 @@ func TestProfileDir(t *testing.T) {
 
 	g.E(err)
 	g.True(file.IsDir())
+}
+
+func TestBrowserExists(t *testing.T) {
+	g := setup(t)
+
+	b := launcher.NewBrowser()
+	b.Revision = 0
+	g.False(b.Exists())
+
+	// fake a broken executable
+	g.E(utils.Mkdir(b.Destination()))
+	g.Cleanup(func() { _ = os.RemoveAll(b.Destination()) })
+	g.False(b.Exists())
 }

--- a/lib/launcher/revision.go
+++ b/lib/launcher/revision.go
@@ -3,4 +3,4 @@
 package launcher
 
 // DefaultRevision for chromium
-const DefaultRevision = 993261
+const DefaultRevision = 983172


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

As I mentioned in https://github.com/go-rod/rod/issues/586, by adding Playwright host can download the prebuilt binaries for linux arm64.
