### PR TITLE
Fix hijacking when fulfilling requests with empty body.

### DIFF
--- a/lib/proto/fetch.go
+++ b/lib/proto/fetch.go
@@ -181,7 +181,7 @@ type FetchFulfillRequest struct {
 	// Body (optional) A response body. If absent, original response body will be used if
 	// the request is intercepted at the response stage and empty body
 	// will be used if the request is intercepted at the request stage.
-	Body []byte `json:"body,omitempty"`
+	Body []byte `json:"body"`
 
 	// ResponsePhrase (optional) A textual representation of responseCode.
 	// If absent, a standard phrase matching responseCode is used.

--- a/lib/proto/fetch.go
+++ b/lib/proto/fetch.go
@@ -178,7 +178,7 @@ type FetchFulfillRequest struct {
 	// over the protocol as text.
 	BinaryResponseHeaders []byte `json:"binaryResponseHeaders,omitempty"`
 
-	// Body (optional) A response body. If absent, original response body will be used if
+	// Body A response body. If absent, original response body will be used if
 	// the request is intercepted at the response stage and empty body
 	// will be used if the request is intercepted at the request stage.
 	Body []byte `json:"body"`

--- a/lib/proto/generate/patch.go
+++ b/lib/proto/generate/patch.go
@@ -68,4 +68,12 @@ func patch(json gson.JSON) {
 	jj.Del("optional")
 	jj, _ = j.Gets(k("name", "deltaY"))
 	jj.Del("optional")
+
+	// removing the optional for the body as we need to distinguish between no body and empty body
+	// with that fix we can send an 'empty body' using `SetBody([]byte{})`
+	// and 'no body' by not calling using 'SetBody()' on the response
+	j, _ = json.Gets("domains", k("domain", "Fetch"), "commands", k("name", "fulfillRequest"), "parameters")
+	jj, _ = j.Gets(k("name", "body"))
+	jj.Del("optional")
+
 }


### PR DESCRIPTION
The issue occurred when I was writing some tests for a backend that uses Protobuf messages (with Twirp as the transport layer). An empty body is the optimized version of "all fields" in the response message are empty.

If I hijack such a request and just call 'ctx.MustLoadResponse()` without doing anything else, this request suddenly failed. I also could not create this kind of response when I needed it for testing.

After removing the `omitempty`, it works fine in all my test cases. I actually don't see any reason why you would want to omit when empty. However, maybe I am forgetting some use cases.