### PR TITLE
Add ability to capture screencast frame and convert it to AVI movie

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-rod/rod
 go 1.16
 
 require (
+	github.com/icza/mjpeg v0.0.0-20210726201846-5ff75d3c479f // indirect
 	github.com/ysmood/goob v0.4.0
 	github.com/ysmood/got v0.29.1
 	github.com/ysmood/gotrace v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/icza/mjpeg v0.0.0-20210726201846-5ff75d3c479f h1:907GjB0sqx3+XKOz5tSeAi8Z9ED7WwQU9hXoclDp+jg=
+github.com/icza/mjpeg v0.0.0-20210726201846-5ff75d3c479f/go.mod h1:Eja3x31oRrEOzl6ihhsxY23gXaTYWLP3Gwj5nMAJ7m0=
 github.com/ysmood/goob v0.4.0 h1:HsxXhyLBeGzWXnqVKtmT9qM7EuVs/XOgkX7T6r1o1AQ=
 github.com/ysmood/goob v0.4.0/go.mod h1:u6yx7ZhS4Exf2MwciFr6nIM8knHQIE22lFpWHnfql18=
 github.com/ysmood/got v0.29.1 h1:7TNTm3Bw5kdBGXFp04qnZ9DqlZ1XS1z1JdeobeJY6Mo=

--- a/page_test.go
+++ b/page_test.go
@@ -971,3 +971,25 @@ func TestPageActionAfterClose(t *testing.T) {
 		g.Eq(err, context.Canceled)
 	}
 }
+
+func TestPageScreenCast(t *testing.T) {
+	g := setup(t)
+
+	{
+		b := rod.New().MustConnect()
+
+		defer b.MustClose()
+
+		p := b.MustPage(g.blank()).MustWaitLoad()
+
+		p.ScreenCastRecord("sample.avi", 6) // Only support .avi video file & frame per second
+		p.ScreenCastStart(100, 1)           // Image quality & frame per second
+
+		p.Navigate("https://google.com")
+
+		time.Sleep(3 * time.Second)
+
+		p.ScreenCastStop()
+		p.MustClose()
+	}
+}

--- a/page_test.go
+++ b/page_test.go
@@ -982,14 +982,36 @@ func TestPageScreenCast(t *testing.T) {
 
 		p := b.MustPage(g.blank()).MustWaitLoad()
 
-		p.ScreenCastRecord("sample.avi", 6) // Only support .avi video file & frame per second
-		p.ScreenCastStart(100, 1)           // Image quality & frame per second
+		// ScreenCastRecord listen PageScreenCastFrame and convert it directly into AVI Movie
+		_, errorRecord := p.ScreenCastRecord("sample.avi", 2) // Only support .avi video file & frame per second
 
-		p.Navigate("https://google.com")
+		if errorRecord != nil {
+			t.Fail()
+		}
+		// ScreenCastStart start listening ScreenCastRecord
+		_, errorStart := p.ScreenCastStart(100, 1) // Image quality & frame per second
+
+		if errorStart != nil {
+			t.Fail()
+		}
+
+		errorNavigate := p.Navigate("https://google.com")
+
+		if errorNavigate != nil {
+			t.Fail()
+		}
 
 		time.Sleep(3 * time.Second)
 
-		p.ScreenCastStop()
+		// ScreenCastStop stop listening ScreenCastRecord
+		_, errorStop := p.ScreenCastStop()
+
+		if errorStop != nil {
+			t.Fail()
+		}
+
 		p.MustClose()
+
+		g.Skip()
 	}
 }


### PR DESCRIPTION
This PR aims to resolve issue #22 regarding the ability to record processes on a running page, this function is like using the `Screenshot` function but with two additional functions as a trigger.

Example usage

```go
func main() {
	browser := rod.New().MustConnect()

	defer browser.MustClose()
	
	page := browser.MustPage(g.blank()).MustWaitLoad()
	
	// ScreenCastRecord listen PageScreenCastFrame and convert it directly into AVI Movie
	_, errorRecord := page.ScreenCastRecord("sample.avi", 6) // Only support .avi video file & frame per second
	
	if errorRecord != nil {
		return errorRecord
	}
	// ScreenCastStart start listening ScreenCastRecord
	_, errorStart := page.ScreenCastStart(100, 1) // Image quality & frame per second
	
	if errorStart != nil {
		return errorStart
	}
	
	errorNavigate := page.Navigate("https://google.com")
	
	if errorNavigate != nil {
		return errorNavigate
	}
	
	time.Sleep(3 * time.Second)
	
	// ScreenCastStop stop listening ScreenCastRecord
	_, errorStop := page.ScreenCastStop()
	
	if errorStop != nil {
		return errorStop
	}
	
	page.MustClose()	
}
```