### PR TITLE
Update examples

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,13 @@ Object model:
 
 ## Run tests
 
-No magic, just `go test`. Read the test template [lab_test.go](../lab_test.go) to get started.
+First, set this environment variable:
+
+```bash
+export GODEBUG="tracebackancestors=1000"
+```
+
+Then, no magic, just `go test`. Read the test template [lab_test.go](../lab_test.go) to get started.
 
 The entry point of tests is [setup_test.go](../setup_test.go). All the test helpers are defined in it.
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -284,7 +284,7 @@ func TestBinarySize(t *testing.T) {
 	stat, err := os.Stat("tmp/translator")
 	g.E(err)
 
-	g.Lte(float64(stat.Size())/1024/1024, 9.3) // mb
+	g.Lte(float64(stat.Size())/1024/1024, 9.4) // mb
 }
 
 func TestBrowserCookies(t *testing.T) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -63,7 +63,7 @@ func Example() {
 // Rod provides a lot of debug options, you can set them with setter methods or use environment variables.
 // Doc for environment variables: https://pkg.go.dev/github.com/go-rod/rod/lib/defaults
 func Example_disable_headless_to_debug() {
-	// Headless runs the browser on foreground, you can also use env "rod=show"
+	// Headless runs the browser on foreground, you can also use flag "-rod=show"
 	// Devtools opens the tab in each new tab opened automatically
 	l := launcher.New().
 		Headless(false).
@@ -84,7 +84,7 @@ func Example_disable_headless_to_debug() {
 
 	// ServeMonitor plays screenshots of each tab. This feature is extremely
 	// useful when debugging with headless mode.
-	// You can also enable it with env rod=monitor
+	// You can also enable it with flag "-rod=monitor"
 	launcher.Open(browser.ServeMonitor(""))
 
 	defer browser.MustClose()

--- a/lib/assets/README.md
+++ b/lib/assets/README.md
@@ -1,3 +1,3 @@
-# Asserts
+# Assets
 
 Static files for the project

--- a/lib/examples/compare-chromedp/click/main.go
+++ b/lib/examples/compare-chromedp/click/main.go
@@ -13,16 +13,16 @@ func main() {
 		MustConnect().
 		Trace(true). // log useful info about what rod is doing
 		Timeout(15 * time.Second).
-		MustPage("https://golang.org/pkg/time/")
+		MustPage("https://pkg.go.dev/time/")
 
 	// wait for footer element is visible (ie, page is loaded)
 	page.MustElement(`body > footer`).MustWaitVisible()
 
 	// find and click "Expand All" link
-	page.MustElement(`#pkg-examples > div`).MustClick()
+	page.MustElement(`#pkg-examples`).MustClick()
 
 	// retrieve the value of the textarea
-	example := page.MustElement(`#example_After .play .input textarea`).MustText()
+	example := page.MustElement(`#example-After textarea`).MustText()
 
 	log.Printf("Go's time.After example:\n%s", example)
 }

--- a/lib/examples/compare-chromedp/eval/main.go
+++ b/lib/examples/compare-chromedp/eval/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	res := rod.New().MustConnect().
 		MustPage("https://www.google.com/").
-		MustElement("#main").
+		MustElement(`input`).
 		MustEval("() => Object.keys(window)")
 
 	log.Printf("window object keys: %v", res)

--- a/lib/examples/compare-chromedp/remote/main.go
+++ b/lib/examples/compare-chromedp/remote/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-rod/rod"
 )
 
-var flagDevToolWsURL = flag.String("devtools-ws-url", "", "DevTools WebSsocket URL")
+var flagDevToolWsURL = flag.String("devtools-ws-url", "", "DevTools WebSocket URL")
 
 // This example demonstrates how to connect to an existing Chrome DevTools
 // instance using a remote WebSocket URL.

--- a/lib/examples/compare-chromedp/screenshot/main.go
+++ b/lib/examples/compare-chromedp/screenshot/main.go
@@ -15,7 +15,7 @@ func main() {
 	browser := rod.New().MustConnect()
 
 	// capture screenshot of an element
-	browser.MustPage("https://google.com").MustElement("#main").MustScreenshot("elementScreenshot.png")
+	browser.MustPage("https://google.com").MustElement("body div").MustScreenshot("elementScreenshot.png")
 
 	// capture entire browser viewport, returning jpg with quality=90
 	buf, err := browser.MustPage("https://brank.as/").Screenshot(true, &proto.PageCaptureScreenshot{

--- a/lib/examples/compare-chromedp/submit/main.go
+++ b/lib/examples/compare-chromedp/submit/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	page.MustElement(`input[name=q]`).MustWaitVisible().MustInput("chromedp").MustType(input.Enter)
 
-	res := page.MustElementR("a", "chromedp").MustParent().MustNext().MustText()
+	res := page.MustElementR("a", "chromedp").MustParent().MustParent().MustNext().MustText()
 
 	log.Printf("got: `%s`", strings.TrimSpace(res))
 }

--- a/lib/examples/compare-chromedp/text/main.go
+++ b/lib/examples/compare-chromedp/text/main.go
@@ -9,8 +9,8 @@ import (
 
 // This example demonstrates  how to extract text from a specific element.
 func main() {
-	page := rod.New().MustConnect().MustPage("https://golang.org/pkg/time")
+	page := rod.New().MustConnect().MustPage("https://pkg.go.dev/time")
 
-	res := page.MustElement("#pkg-overview").MustText()
+	res := page.MustElement("#pkg-overview").MustParent().MustText()
 	log.Println(strings.TrimSpace(res))
 }

--- a/lib/examples/translator/main.go
+++ b/lib/examples/translator/main.go
@@ -1,19 +1,26 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"os"
+	"log"
+	"strings"
 
 	"github.com/go-rod/rod"
 )
 
 func main() {
-	// get the first commandline argument
-	source := os.Args[1]
+	flag.Parse()
+
+	// get the commandline arguments
+	source := strings.TrimSpace(strings.Join(flag.Args(), " "))
+	if source == "" {
+		log.Fatal("usage: go run main.go -- 'This is the phrase to translate to Spanish.'")
+	}
 
 	browser := rod.New().MustConnect()
 
-	page := browser.MustPage("https://translate.google.com")
+	page := browser.MustPage("https://translate.google.com/?sl=auto&tl=es&op=translate")
 
 	el := page.MustElement(`textarea[aria-label="Source text"]`)
 

--- a/lib/js/helper.js
+++ b/lib/js/helper.js
@@ -1,8 +1,8 @@
 // The reason to use an extra js file to hold the functions is the lint and IDE support.
 // To debug just add "debugger" keyword to the line you want to pause, then run something like:
 //
-//     go run ./lib/js/generate
-//     rod=show,devtools go test -run ^TestClick$
+//     go run ./lib/js/generate/main.go
+//     go test -run ^TestClick$ -- -rod=show,devtools
 
 const functions = {
   element(selector) {


### PR DESCRIPTION
This PR updates a few of the provided examples based upon recent changes made to target websites.

## Test on local before making the PR

I ran the `simple-check` but the linter doesn't like `go version go1.19beta1 linux/amd64`:

```bash
$ go run ./lib/utils/simple-check
[exec]2022/06/16 15:51:33 go run github.com/ysmood/golangci-lint@latest
go: downloading github.com/ysmood/golangci-lint v0.5.2
Download golangci-lint: https://github.com/golangci/golangci-lint/releases/download/v1.46.1/golangci-lint-1.46.1-linux-amd64.tar.gz
Progress: 00% 100%
Downloaded: /tmp/golangci-lint-1.46.1-linux-amd64.tar.gz
/home/glenn/go/bin/golangci-lint1.46.1 run --fix
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
2022/06/16 15:51:38 exit status 2
exit status 1
panic: exit status 1
go: downloading github.com/ysmood/golangci-lint v0.5.2
Download golangci-lint: https://github.com/golangci/golangci-lint/releases/download/v1.46.1/golangci-lint-1.46.1-linux-amd64.tar.gz
Progress: 00% 100%
Downloaded: /tmp/golangci-lint-1.46.1-linux-amd64.tar.gz
/home/glenn/go/bin/golangci-lint1.46.1 run --fix
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
2022/06/16 15:51:38 exit status 2
exit status 1


goroutine 1 [running]:
github.com/go-rod/rod/lib/utils.ExecLine(0x1, {0x507f73?, 0x0?}, {0x0?, 0x0?, 0xc0000081a0?})
	/home/glenn/go/src/github.com/gmlewis/rod/lib/utils/utils.go:289 +0x454
github.com/go-rod/rod/lib/utils.Exec(...)
	/home/glenn/go/src/github.com/gmlewis/rod/lib/utils/utils.go:262
main.main()
	/home/glenn/go/src/github.com/gmlewis/rod/lib/utils/simple-check/main.go:6 +0x35
exit status 2
```
