### PR TITLE
fix "panic: unaligned 64-bit atomic operation"

### DIFF
--- a/lib/cdp/client.go
+++ b/lib/cdp/client.go
@@ -44,12 +44,12 @@ type WebSocketable interface {
 
 // Client is a devtools protocol connection instance.
 type Client struct {
+	count uint64
+
 	ws WebSocketable
 
 	pending sync.Map    // pending requests
 	event   chan *Event // events from browser
-
-	count uint64
 
 	logger utils.Logger
 }


### PR DESCRIPTION
fix "panic: unaligned 64-bit atomic operation" on 32bit OS like Windows 7 32bit

[see go/src/sync/atomic/doc.go ](https://github.com/golang/go/blob/d38f1d13fa413436d38d86fe86d6a146be44bb84/src/sync/atomic/doc.go#L57)