### PR TITLE
fix unpack params with asasalint

### DIFF
--- a/must.go
+++ b/must.go
@@ -867,7 +867,7 @@ func (el *Element) MustWaitStable() *Element {
 
 // MustWait is similar to Element.Wait
 func (el *Element) MustWait(js string, params ...interface{}) *Element {
-	el.e(el.Wait(Eval(js, params)))
+	el.e(el.Wait(Eval(js, params...)))
 	return el
 }
 


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

## How

I create a [linter](https://github.com/alingse/asasalint) about pass []any as any into  variadic function

the linter output

```
.../github/rod/must.go:870:24: pass []any as any to func Eval func(js string, args ...interface{}) *github.com/go-rod/rod.EvalOptions
```



