### PR TITLE
Fix unpack params with asasalint

### DIFF
--- a/element_test.go
+++ b/element_test.go
@@ -781,6 +781,23 @@ func TestElementEqual(t *testing.T) {
 	g.False(el1.MustEqual(el3))
 }
 
+func TestElementMustWait(t *testing.T) {
+	g := setup(t)
+
+	p := g.page.MustNavigate(g.srcFile("fixtures/describe.html"))
+	e1 := p.MustElement("body > ul > li")
+	g.Eq(e1.MustText(), "coffee")
+
+	params := []interface{}{1, 3, 4}
+	go func() {
+		utils.Sleep(0.3)
+		e1.MustEval(`(a, b, c) => this.innerText = 'x'.repeat(a + b + c)`, params...)
+	}()
+
+	e1.MustWait(`(a, b, c) => this.innerText.length === (a + b + c)`, params...)
+	g.Eq(e1.MustText(), "xxxxxxxx")
+}
+
 func TestElementFromPointErr(t *testing.T) {
 	g := setup(t)
 

--- a/must.go
+++ b/must.go
@@ -867,7 +867,7 @@ func (el *Element) MustWaitStable() *Element {
 
 // MustWait is similar to Element.Wait
 func (el *Element) MustWait(js string, params ...interface{}) *Element {
-	el.e(el.Wait(Eval(js, params)))
+	el.e(el.Wait(Eval(js, params...)))
 	return el
 }
 

--- a/page_eval_test.go
+++ b/page_eval_test.go
@@ -38,6 +38,8 @@ func TestPageEval(t *testing.T) {
 		(a, b) => a + b
 	`, 1, 2).Int())
 
+	g.Eq(10, page.MustEval(`(a, b, c, d) => a + b + c + d`, 1, 2, 3, 4).Int())
+
 	g.Eq(page.MustEval(`function() {
 		return 11
 	}`).Int(), 11)


### PR DESCRIPTION
see https://github.com/go-rod/rod/pull/642 before

```bash
rod/must.go:870:24: pass []any as any to func Eval func(js string, args ...interface{}) *github.com/go-rod/rod.EvalOptions
```

run local test success
```bash
$go test -coverprofile=coverage.out -run TestElementMustWait
parallel test 4
PASS
coverage: 13.2% of statements
ok      github.com/go-rod/rod   5.918s
```

