### PR TITLE
Add HijackOnce

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package rod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-rod/rod/lib/proto"
@@ -181,3 +182,6 @@ type ErrPageNotFound struct {
 func (e *ErrPageNotFound) Error() string {
 	return "cannot find page"
 }
+
+// hijack skipped
+var ErrHijackSkipped = errors.New("hijack skipped")

--- a/error.go
+++ b/error.go
@@ -183,5 +183,5 @@ func (e *ErrPageNotFound) Error() string {
 	return "cannot find page"
 }
 
-// hijack skipped
+// ErrHijackSkipped triggered at hijack skipped
 var ErrHijackSkipped = errors.New("hijack skipped")

--- a/error.go
+++ b/error.go
@@ -3,7 +3,6 @@ package rod
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/go-rod/rod/lib/utils"
@@ -20,9 +19,7 @@ func (e *ErrTry) Error() string {
 }
 
 // Is interface
-func (e *ErrTry) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrTry) Is(err error) bool { _, ok := err.(*ErrTry); return ok }
 
 // Unwrap stdlib interface
 func (e *ErrTry) Unwrap() error {
@@ -42,9 +39,7 @@ func (e *ErrExpectElement) Error() string {
 }
 
 // Is interface
-func (e *ErrExpectElement) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrExpectElement) Is(err error) bool { _, ok := err.(*ErrExpectElement); return ok }
 
 // ErrExpectElements error
 type ErrExpectElements struct {
@@ -56,9 +51,7 @@ func (e *ErrExpectElements) Error() string {
 }
 
 // Is interface
-func (e *ErrExpectElements) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrExpectElements) Is(err error) bool { _, ok := err.(*ErrExpectElements); return ok }
 
 // ErrElementNotFound error
 type ErrElementNotFound struct {
@@ -85,9 +78,7 @@ func (e *ErrObjectNotFound) Error() string {
 }
 
 // Is interface
-func (e *ErrObjectNotFound) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrObjectNotFound) Is(err error) bool { _, ok := err.(*ErrObjectNotFound); return ok }
 
 // ErrEval error
 type ErrEval struct {
@@ -100,9 +91,7 @@ func (e *ErrEval) Error() string {
 }
 
 // Is interface
-func (e *ErrEval) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrEval) Is(err error) bool { _, ok := err.(*ErrEval); return ok }
 
 // ErrNavigation error
 type ErrNavigation struct {
@@ -114,9 +103,7 @@ func (e *ErrNavigation) Error() string {
 }
 
 // Is interface
-func (e *ErrNavigation) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrNavigation) Is(err error) bool { _, ok := err.(*ErrNavigation); return ok }
 
 // ErrPageCloseCanceled error
 type ErrPageCloseCanceled struct {
@@ -144,9 +131,7 @@ func (e *ErrInvisibleShape) Error() string {
 }
 
 // Is interface
-func (e *ErrInvisibleShape) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrInvisibleShape) Is(err error) bool { _, ok := err.(*ErrInvisibleShape); return ok }
 
 // Unwrap ...
 func (e *ErrInvisibleShape) Unwrap() error {
@@ -169,9 +154,7 @@ func (e *ErrCovered) Unwrap() error {
 }
 
 // Is interface
-func (e *ErrCovered) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrCovered) Is(err error) bool { _, ok := err.(*ErrCovered); return ok }
 
 // ErrNoPointerEvents error.
 type ErrNoPointerEvents struct {
@@ -189,9 +172,7 @@ func (e *ErrNoPointerEvents) Unwrap() error {
 }
 
 // Is interface
-func (e *ErrNoPointerEvents) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrNoPointerEvents) Is(err error) bool { _, ok := err.(*ErrNoPointerEvents); return ok }
 
 // ErrPageNotFound error
 type ErrPageNotFound struct {

--- a/fixtures/hijack.html
+++ b/fixtures/hijack.html
@@ -15,6 +15,7 @@
         createDiv('a', `${res.status} ${data.text}`)
         createDiv('err', '')
       } catch (error) {
+        createDiv('a', "")
         createDiv('err', `${error}`)
       }
     }

--- a/fixtures/hijack.html
+++ b/fixtures/hijack.html
@@ -1,0 +1,23 @@
+<html>
+  <body></body>
+  <script>
+    const createDiv = (id, data) => {
+      const div = document.createElement('div')
+      div.innerText = data
+      div.id = id
+      document.body.appendChild(div)
+    }
+
+    const main = async () => {
+      try {
+        const res = await fetch('/a')
+        const data = await res.json()
+        createDiv('a', `${res.status} ${data.text}`)
+        createDiv('err', '')
+      } catch (error) {
+        createDiv('err', `${error}`)
+      }
+    }
+    main()
+  </script>
+</html>

--- a/fixtures/hijack.html
+++ b/fixtures/hijack.html
@@ -15,7 +15,7 @@
         createDiv('a', `${res.status} ${data.text}`)
         createDiv('err', '')
       } catch (error) {
-        createDiv('a', "")
+        createDiv('a', '')
         createDiv('err', `${error}`)
       }
     }

--- a/hijack.go
+++ b/hijack.go
@@ -32,7 +32,7 @@ func (p *Page) HijackRequests() *HijackRouter {
 	return newHijackRouter(p.browser, p).initEvents()
 }
 
-// hijack request once.
+// HijackOnce hijack request once.
 func (p *Page) HijackOnce() *HijackOnce {
 	return NewHijackOnce(p)
 }
@@ -153,7 +153,7 @@ type hijackHandler struct {
 	handler func(*Hijack)
 }
 
-// new hijack from page
+// NewHijackOnce create hijack from page.
 func NewHijackOnce(page *Page) *HijackOnce {
 	return &HijackOnce{
 		page:    page,
@@ -161,14 +161,14 @@ func NewHijackOnce(page *Page) *HijackOnce {
 	}
 }
 
-// hijack once
+// HijackOnce is a one-time hijack.
 type HijackOnce struct {
 	page    *Page
 	enable  *proto.FetchEnable
 	disable *proto.FetchDisable
 }
 
-// set pattern and resourceType
+// Set pattern and resourceType
 func (h *HijackOnce) Set(pattern string, resourceType proto.NetworkResourceType) *HijackOnce {
 	return h.SetPattern(&proto.FetchRequestPattern{
 		URLPattern:   pattern,
@@ -176,7 +176,7 @@ func (h *HijackOnce) Set(pattern string, resourceType proto.NetworkResourceType)
 	})
 }
 
-// Set pattern directly
+// SetPattern set pattern directly
 func (h *HijackOnce) SetPattern(pattern *proto.FetchRequestPattern) *HijackOnce {
 	h.enable = &proto.FetchEnable{
 		Patterns: []*proto.FetchRequestPattern{pattern},
@@ -206,7 +206,7 @@ func (h *HijackOnce) Start(handler func(*Hijack)) (func() error, error) {
 	}, nil
 }
 
-// Start hijack.
+// MustStart starts hijack.
 // It will panic when receive an error.
 func (h *HijackOnce) MustStart(handler func(*Hijack)) func() {
 	wait, err := h.Start(handler)
@@ -232,7 +232,7 @@ func (h *HijackOnce) handle(e *proto.FetchRequestPaused, fn func(*Hijack)) error
 	return hijack.Finish(e, h.page)
 }
 
-// new hijack context
+// NewHijack creates hijack context.
 func NewHijack(ctx context.Context, b *Browser, e *proto.FetchRequestPaused) *Hijack {
 	return &Hijack{
 		Event:    e,
@@ -324,7 +324,7 @@ func (h *Hijack) handleErr(err error) {
 	}
 }
 
-// new hijack request from event FetchRequestPaused.
+// NewHijackRequest creates hijack request from event FetchRequestPaused.
 func NewHijackRequest(e *proto.FetchRequestPaused) *HijackRequest {
 	return &HijackRequest{
 		event: e,
@@ -332,7 +332,7 @@ func NewHijackRequest(e *proto.FetchRequestPaused) *HijackRequest {
 	}
 }
 
-// new request from event FetchRequestPaused.
+// RequestFromEvent creates request from event FetchRequestPaused.
 func RequestFromEvent(e *proto.FetchRequestPaused) *http.Request {
 	headers := http.Header{}
 	for k, v := range e.Request.Headers {
@@ -425,7 +425,7 @@ func (ctx *HijackRequest) IsNavigation() bool {
 	return ctx.Type() == proto.NetworkResourceTypeDocument
 }
 
-// new hijack response from event FetchRequestPaused.
+// NewHijackResponse creates hijack response from event FetchRequestPaused.
 func NewHijackResponse(e *proto.FetchRequestPaused) *HijackResponse {
 	return &HijackResponse{
 		payload: &proto.FetchFulfillRequest{

--- a/hijack_test.go
+++ b/hijack_test.go
@@ -491,7 +491,8 @@ func TestHijackOnceDisableFetchError(t *testing.T) {
 	g.page.MustNavigate(s.URL())
 	err := rod.Try(wait)
 	g.Err(err)
-	new(proto.FetchDisable).Call(g.page)
+	err = new(proto.FetchDisable).Call(g.page)
+	g.E(err)
 
 	g.Eq("200 test", g.page.MustElement("#a").MustText())
 	g.Eq("", g.page.MustElement("#err").MustText())

--- a/hijack_test.go
+++ b/hijack_test.go
@@ -430,6 +430,22 @@ func TestHijackOnceNotSet(t *testing.T) {
 	g.Err(err)
 }
 
+func TestHijackOnceEnableError(t *testing.T) {
+	g := setup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	once := g.page.Context(ctx).HijackOnce()
+	once.Set("a", proto.NetworkResourceTypeXHR)
+	err := rod.Try(func() {
+		_ = once.MustStart(func(ctx *rod.Hijack) {
+			panic("should not come to here")
+		})
+	})
+	g.Err(err)
+}
+
 func TestHijackOnceStageResponse(t *testing.T) {
 	g := setup(t)
 

--- a/hijack_test.go
+++ b/hijack_test.go
@@ -97,6 +97,11 @@ func TestHijack(t *testing.T) {
 		ctx.MustLoadResponse()
 	})
 
+	err := router.Add("(", "", func(h *rod.Hijack) {
+		panic("should not come to here")
+	})
+	g.Err(err)
+
 	go router.Run()
 
 	g.page.MustNavigate(s.URL())
@@ -379,4 +384,112 @@ func TestHandleAuth(t *testing.T) {
 	g.Err(wait())
 	wait2()
 	page2.MustClose()
+}
+
+func TestHijackOnce(t *testing.T) {
+	g := setup(t)
+
+	s := g.Serve()
+
+	// to simulate a backend server
+	s.Route("/", slash("fixtures/fetch.html"))
+	s.Mux.HandleFunc("/a", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			panic("wrong http method")
+		}
+
+		g.Eq("header", r.Header.Get("Test"))
+
+		b, err := ioutil.ReadAll(r.Body)
+		g.E(err)
+		g.Eq("a", string(b))
+
+		g.HandleHTTP(".html", "test")(w, r)
+	})
+	s.Route("/b", "", "b")
+
+	once := g.page.HijackOnce()
+	once.Set(s.URL("/a"), proto.NetworkResourceTypeXHR)
+	wait := once.MustStart(func(ctx *rod.Hijack) {
+		r := ctx.Request.SetContext(g.Context())
+		r.Req().Header.Set("Test", "header") // override request header
+		r.SetBody([]byte("test"))            // override request body
+		r.SetBody(123)                       // override request body
+		r.SetBody(r.Body())                  // override request body
+
+		type MyState struct {
+			Val int
+		}
+
+		ctx.CustomState = &MyState{10}
+
+		g.Eq(http.MethodPost, r.Method())
+		g.Eq(s.URL("/a"), r.URL().String())
+
+		g.Eq(proto.NetworkResourceTypeXHR, ctx.Request.Type())
+		g.Is(ctx.Request.IsNavigation(), false)
+		g.Has(ctx.Request.Header("Origin"), s.URL())
+		g.Len(ctx.Request.Headers(), 6)
+		g.True(ctx.Request.JSONBody().Nil())
+
+		// send request load response from real destination as the default value to hijack
+		ctx.MustLoadResponse()
+
+		g.Eq(200, ctx.Response.Payload().ResponseCode)
+
+		// override status code
+		ctx.Response.Payload().ResponseCode = http.StatusCreated
+
+		g.Eq("4", ctx.Response.Headers().Get("Content-Length"))
+		g.Has(ctx.Response.Headers().Get("Content-Type"), "text/html; charset=utf-8")
+
+		// override response header
+		ctx.Response.SetHeader("Set-Cookie", "key=val")
+
+		// override response body
+		ctx.Response.SetBody([]byte("test"))
+		ctx.Response.SetBody("test")
+		ctx.Response.SetBody(map[string]string{
+			"text": "test",
+		})
+
+		g.Eq("{\"text\":\"test\"}", ctx.Response.Body())
+	})
+
+	g.page.MustNavigate(s.URL())
+	wait()
+
+	g.Eq("201 test key=val", g.page.MustElement("#a").MustText())
+	g.Eq("b", g.page.MustElement("#b").MustText())
+}
+
+func TestHijackOnceNotSet(t *testing.T) {
+	g := setup(t)
+
+	s := g.Serve()
+
+	// to simulate a backend server
+	s.Route("/", slash("fixtures/fetch.html"))
+	s.Mux.HandleFunc("/a", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			panic("wrong http method")
+		}
+
+		g.Eq("header", r.Header.Get("Test"))
+
+		b, err := ioutil.ReadAll(r.Body)
+		g.E(err)
+		g.Eq("a", string(b))
+
+		g.HandleHTTP(".html", "test")(w, r)
+	})
+	s.Route("/b", "", "b")
+
+	once := g.page.HijackOnce()
+	err := rod.Try(func() {
+		_ = once.MustStart(func(ctx *rod.Hijack) {
+			panic("should not come to here")
+		})
+	})
+	g.Err(err)
 }

--- a/lib/proto/a_patch.go
+++ b/lib/proto/a_patch.go
@@ -8,7 +8,9 @@ import (
 
 // TimeSinceEpoch UTC time in seconds, counted from January 1, 1970.
 // To convert a time.Time to TimeSinceEpoch, for example:
-//     proto.TimeSinceEpoch(time.Now().Unix())
+//
+//	proto.TimeSinceEpoch(time.Now().Unix())
+//
 // For session cookie, the value should be -1.
 type TimeSinceEpoch float64
 

--- a/lib/utils/sleeper.go
+++ b/lib/utils/sleeper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	mr "math/rand"
-	"reflect"
 	"sync"
 	"time"
 )
@@ -30,9 +29,7 @@ func (e *ErrMaxSleepCount) Error() string {
 }
 
 // Is interface
-func (e *ErrMaxSleepCount) Is(err error) bool {
-	return reflect.TypeOf(e) == reflect.TypeOf(err)
-}
+func (e *ErrMaxSleepCount) Is(err error) bool { _, ok := err.(*ErrMaxSleepCount); return ok }
 
 // CountSleeper wakes immediately. When counts to the max returns *ErrMaxSleepCount
 func CountSleeper(max int) Sleeper {


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

Add a new feature HijackOnce.
It can hijack request of page once.

It can hijack in response stage.
That means you can get the response body without call `http.Client.Do` directly.