### PR TITLE
Use provided proxy to download chrome binary

### DIFF
--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -100,8 +100,8 @@ type Browser struct {
 	// Proxy to use (http/socks5). Default is nil.
 	proxyURL *url.URL
 
-	// ignore proxy certificate validation
-	ignoreProxyCertificates bool
+	// IgnoreCerts skips proxy certificate validation
+	IgnoreCerts bool
 }
 
 // NewBrowser with default values
@@ -250,7 +250,7 @@ func (lc *Browser) httpClient() *http.Client {
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 	}
-	if lc.ignoreProxyCertificates {
+	if lc.IgnoreCerts {
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -99,6 +99,9 @@ type Browser struct {
 
 	// Proxy to use (http/socks5). Default is nil.
 	proxyURL *url.URL
+
+	// ignore proxy certificate validation
+	ignoreProxyCertificates bool
 }
 
 // NewBrowser with default values
@@ -246,9 +249,11 @@ func (lc *Browser) download(ctx context.Context, u string) error {
 func (lc *Browser) httpClient() *http.Client {
 	transport := &http.Transport{
 		DisableKeepAlives: true,
-		TLSClientConfig: &tls.Config{
+	}
+	if lc.ignoreProxyCertificates {
+		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
-		},
+		}
 	}
 	if lc.proxyURL != nil {
 		transport.Proxy = http.ProxyURL(lc.proxyURL)

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -3,12 +3,14 @@ package launcher
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,6 +96,9 @@ type Browser struct {
 
 	// LockPort a tcp port to prevent race downloading. Default is 2968 .
 	LockPort int
+
+	// Proxy to use (http/socks5)
+	proxyURL *url.URL
 }
 
 // NewBrowser with default values
@@ -135,6 +140,16 @@ func (lc *Browser) Download() (err error) {
 	}
 
 	return lc.download(lc.Context, u)
+}
+
+// SetHttpClient for the browser instance
+func (lc *Browser) Proxy(URL string) error {
+	proxyURL, err := url.Parse(URL)
+	if err != nil {
+		return err
+	}
+	lc.proxyURL = proxyURL
+	return err
 }
 
 func (lc *Browser) fastestHost() (fastest string, err error) {
@@ -229,7 +244,16 @@ func (lc *Browser) download(ctx context.Context, u string) error {
 }
 
 func (lc *Browser) httpClient() *http.Client {
-	return &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	transport := &http.Transport{
+		DisableKeepAlives: true,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	if lc.proxyURL != nil {
+		transport.Proxy = http.ProxyURL(lc.proxyURL)
+	}
+	return &http.Client{Transport: transport}
 }
 
 // Get is a smart helper to get the browser executable path.

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -97,7 +97,7 @@ type Browser struct {
 	// LockPort a tcp port to prevent race downloading. Default is 2968 .
 	LockPort int
 
-	// Proxy to use (http/socks5)
+	// Proxy to use (http/socks5). Default is nil.
 	proxyURL *url.URL
 }
 
@@ -142,7 +142,7 @@ func (lc *Browser) Download() (err error) {
 	return lc.download(lc.Context, u)
 }
 
-// SetHttpClient for the browser instance
+// Proxy sets the proxy for chrome download
 func (lc *Browser) Proxy(URL string) error {
 	proxyURL, err := url.Parse(URL)
 	if err != nil {

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -304,7 +304,7 @@ func (l *Launcher) RemoteDebuggingPort(port int) *Launcher {
 
 // Proxy for the browser
 func (l *Launcher) Proxy(host string) *Launcher {
-	l.browser.Proxy(host)
+	_ = l.browser.Proxy(host)
 	return l.Set(flags.ProxyServer, host)
 }
 

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -268,9 +268,6 @@ func (l *Launcher) IgnoreCerts(pks []crypto.PublicKey) error {
 
 	l.Set("ignore-certificate-errors-spki-list", spkis...)
 
-	// Configure the browser proxy to skip certificate validation
-	l.browser.ignoreProxyCertificates = true
-
 	return nil
 }
 

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -268,6 +268,9 @@ func (l *Launcher) IgnoreCerts(pks []crypto.PublicKey) error {
 
 	l.Set("ignore-certificate-errors-spki-list", spkis...)
 
+	// Configure the browser proxy to skip certificate validation
+	l.browser.ignoreProxyCertificates = true
+
 	return nil
 }
 

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -304,6 +304,7 @@ func (l *Launcher) RemoteDebuggingPort(port int) *Launcher {
 
 // Proxy for the browser
 func (l *Launcher) Proxy(host string) *Launcher {
+	l.browser.Proxy(host)
 	return l.Set(flags.ProxyServer, host)
 }
 

--- a/lib/launcher/launcher_test.go
+++ b/lib/launcher/launcher_test.go
@@ -346,3 +346,10 @@ func TestIgnoreCerts_InvalidCert(t *testing.T) {
 		g.Fatalf("IgnoreCerts: %s", err)
 	}
 }
+
+func TestIgnoreCerts_BrowserProxySkipValidation(t *testing.T) {
+	g := setup(t)
+	b := launcher.NewBrowser()
+	// certificate validation skip is disabled by default
+	g.False(b.IgnoreCerts)
+}

--- a/lib/launcher/launcher_test.go
+++ b/lib/launcher/launcher_test.go
@@ -83,10 +83,13 @@ func TestDownload(t *testing.T) {
 	g.Nil(os.Stat(b.Dir))
 
 	// download chrome with a proxy
-	_ = os.RemoveAll(b.Dir)
-	p := httptest.NewServer(&httputil.ReverseProxy{Director: func(_ *http.Request) {}})
+	// should fail with self signed certificate
+	p := httptest.NewTLSServer(&httputil.ReverseProxy{Director: func(_ *http.Request) {}})
 	defer p.Close()
 	g.E(b.Proxy(p.URL))
+	g.NotNil(b.Download())
+	// should instead be successful with ignore certificate
+	b.IgnoreCerts = true
 	g.E(b.Download())
 	g.Nil(os.Stat(b.Dir))
 }

--- a/lib/launcher/launcher_test.go
+++ b/lib/launcher/launcher_test.go
@@ -86,6 +86,10 @@ func TestDownload(t *testing.T) {
 	// should fail with self signed certificate
 	p := httptest.NewTLSServer(&httputil.ReverseProxy{Director: func(_ *http.Request) {}})
 	defer p.Close()
+	// invalid proxy URL should trigger an error
+	err := b.Proxy(`invalid.escaping%%2`)
+	g.Eq(err.Error(), `parse "invalid.escaping%%2": invalid URL escape "%%2"`)
+
 	g.E(b.Proxy(p.URL))
 	g.NotNil(b.Download())
 	// should instead be successful with ignore certificate


### PR DESCRIPTION
## Description
This PR uses the provided proxy from chrome in the launcher to configure the http client at `lib/launcher/browser.go`, allowing chrome binaries to be downloaded through a custom proxy. Previously, the custom http client created with the function `httpClient()` in `browser.go` performed direct connections as the `Transport.Proxy` was nil.