### PR TITLE
feat: New api SetBlockedURLs

### DIFF
--- a/must.go
+++ b/must.go
@@ -221,6 +221,12 @@ func (p *Page) MustSetUserAgent(req *proto.NetworkSetUserAgentOverride) *Page {
 	return p
 }
 
+// MustSetBlockedURLs is similar to Page.SetBlockedURLs
+func (p *Page) MustSetBlockedURLs(urls ...string) *Page {
+	p.e(p.SetBlockedURLs(urls))
+	return p
+}
+
 // MustNavigate is similar to Page.Navigate
 func (p *Page) MustNavigate(url string) *Page {
 	p.e(p.Navigate(url))

--- a/page.go
+++ b/page.go
@@ -154,8 +154,8 @@ func (p *Page) SetUserAgent(req *proto.NetworkSetUserAgentOverride) error {
 }
 
 // SetBlockedURLs For some requests that do not want to be triggered, such as some dangerous operations, delete, quit logout, etc.
-// Wildcards ('*') are allowed,such as ["*/api/logout/*","delete",].
-// NOTE: if you set this pattern `""` it will block all requests
+// Wildcards ('*') are allowed, such as ["*/api/logout/*","delete"].
+// NOTE: if you set empty pattern "", it will block all requests.
 func (p *Page) SetBlockedURLs(urls []string) error {
 	if len(urls) == 0 {
 		return nil

--- a/page.go
+++ b/page.go
@@ -153,6 +153,15 @@ func (p *Page) SetUserAgent(req *proto.NetworkSetUserAgentOverride) error {
 	return req.Call(p)
 }
 
+// SetBlockedURLs For some requests that do not want to be triggered, such as some dangerous operations, delete, quit logout, etc.
+// Wildcards ('*') are allowed,such as ["*/api/logout/*","delete",]
+func (p *Page) SetBlockedURLs(urls []string) error {
+	if urls == nil {
+		return proto.NetworkSetBlockedURLs{}.Call(p)
+	}
+	return proto.NetworkSetBlockedURLs{Urls: urls}.Call(p)
+}
+
 // Navigate to the url. If the url is empty, "about:blank" will be used.
 // It will return immediately after the server responds the http header.
 func (p *Page) Navigate(url string) error {

--- a/page.go
+++ b/page.go
@@ -154,10 +154,11 @@ func (p *Page) SetUserAgent(req *proto.NetworkSetUserAgentOverride) error {
 }
 
 // SetBlockedURLs For some requests that do not want to be triggered, such as some dangerous operations, delete, quit logout, etc.
-// Wildcards ('*') are allowed,such as ["*/api/logout/*","delete",]
+// Wildcards ('*') are allowed,such as ["*/api/logout/*","delete",].
+// NOTE: if you set this pattern `""` it will block all requests
 func (p *Page) SetBlockedURLs(urls []string) error {
-	if urls == nil {
-		return proto.NetworkSetBlockedURLs{}.Call(p)
+	if len(urls) == 0 {
+		return nil
 	}
 	return proto.NetworkSetBlockedURLs{Urls: urls}.Call(p)
 }

--- a/page_test.go
+++ b/page_test.go
@@ -78,9 +78,11 @@ func TestSetCookies(t *testing.T) {
 func TestSetBlockedURLs(t *testing.T) {
 	g := setup(t)
 	page := g.newPage()
-	var urlsPattern = []string{"/globe/flag.obj", "*/data/data.json*"}
+	var urlsPattern = []string{}
 	page.EnableDomain(proto.NetworkEnable{})
-	err := page.SetBlockedURLs(urlsPattern)
+	err := page.MustSetBlockedURLs(urlsPattern...)
+	urlsPattern = append(urlsPattern, "*.js")
+	err = page.MustSetBlockedURLs(urlsPattern...)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/page_test.go
+++ b/page_test.go
@@ -3,6 +3,7 @@ package rod_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image/png"
 	"math"
 	"net/http"
@@ -79,7 +80,10 @@ func TestSetBlockedURLs(t *testing.T) {
 	page := g.newPage()
 	var urlsPattern = []string{"/globe/flag.obj", "*/data/data.json*"}
 	page.EnableDomain(proto.NetworkEnable{})
-	page.SetBlockedURLs(urlsPattern)
+	err := page.SetBlockedURLs(urlsPattern)
+	if err != nil {
+		fmt.Println(err)
+	}
 	go page.EachEvent(
 		func(e *proto.NetworkLoadingFailed) {
 			g.Eq(e.BlockedReason, proto.NetworkBlockedReasonInspector)

--- a/page_test.go
+++ b/page_test.go
@@ -80,9 +80,9 @@ func TestSetBlockedURLs(t *testing.T) {
 	page := g.newPage()
 	var urlsPattern = []string{}
 	page.EnableDomain(proto.NetworkEnable{})
-	err := page.MustSetBlockedURLs(urlsPattern...)
+	page.MustSetBlockedURLs(urlsPattern...)
 	urlsPattern = append(urlsPattern, "*.js")
-	err = page.MustSetBlockedURLs(urlsPattern...)
+	err := page.MustSetBlockedURLs(urlsPattern...)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/page_test.go
+++ b/page_test.go
@@ -74,6 +74,20 @@ func TestSetCookies(t *testing.T) {
 	})
 }
 
+func TestSetBlockedURLs(t *testing.T) {
+	g := setup(t)
+	page := g.newPage()
+	var urlsPattern = []string{"/globe/flag.obj", "*/data/data.json*"}
+	page.EnableDomain(proto.NetworkEnable{})
+	page.SetBlockedURLs(urlsPattern)
+	go page.EachEvent(
+		func(e *proto.NetworkLoadingFailed) {
+			g.Eq(e.BlockedReason, proto.NetworkBlockedReasonInspector)
+		},
+	)
+	page.MustNavigate("https://github.com")
+}
+
 func TestSetExtraHeaders(t *testing.T) {
 	g := setup(t)
 


### PR DESCRIPTION
Add api SetBlockedURLs for Page to block some requests from being sent, such as some dangerous operations, delete quit, logout, etc.Wildcards ('*') are allowed,such as ["*/api/logout/*","delete",]

# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
