### PR TITLE
`Element.ShadowRoot` returns error when `ShadowRoots` is empty

### DIFF
--- a/element.go
+++ b/element.go
@@ -18,6 +18,7 @@ import (
 )
 
 var (
+	// ErrNoShadowRoot is calling ShadowRoot on an Element with no shadow root
 	ErrNoShadowRoot = errors.New("element has no shadow root")
 )
 

--- a/element.go
+++ b/element.go
@@ -17,11 +17,6 @@ import (
 	"github.com/go-rod/rod/lib/utils"
 )
 
-var (
-	// ErrNoShadowRoot is calling ShadowRoot on an Element with no shadow root
-	ErrNoShadowRoot = errors.New("element has no shadow root")
-)
-
 // Element implements these interfaces
 var _ proto.Client = &Element{}
 var _ proto.Contextable = &Element{}
@@ -408,7 +403,7 @@ func (el *Element) ShadowRoot() (*Element, error) {
 
 	// though now it's an array, w3c changed the spec of it to be a single.
 	if len(node.ShadowRoots) == 0 {
-		return nil, ErrNoShadowRoot
+		return nil, &ErrNoShadowRoot{el}
 	}
 	id := node.ShadowRoots[0].BackendNodeID
 

--- a/element.go
+++ b/element.go
@@ -17,6 +17,10 @@ import (
 	"github.com/go-rod/rod/lib/utils"
 )
 
+var (
+	ErrNoShadowRoot = errors.New("element has no shadow root")
+)
+
 // Element implements these interfaces
 var _ proto.Client = &Element{}
 var _ proto.Contextable = &Element{}
@@ -402,6 +406,9 @@ func (el *Element) ShadowRoot() (*Element, error) {
 	}
 
 	// though now it's an array, w3c changed the spec of it to be a single.
+	if len(node.ShadowRoots) == 0 {
+		return nil, ErrNoShadowRoot
+	}
 	id := node.ShadowRoots[0].BackendNodeID
 
 	shadowNode, err := proto.DOMResolveNode{BackendNodeID: id}.Call(el)

--- a/element_test.go
+++ b/element_test.go
@@ -284,6 +284,10 @@ func TestShadowDOM(t *testing.T) {
 		g.mc.stubErr(1, proto.DOMResolveNode{})
 		el.MustShadowRoot()
 	})
+
+	elNoShadow := p.MustElement("script")
+	_, err := elNoShadow.ShadowRoot()
+	g.True((&rod.ErrNoShadowRoot{}).Is(err))
 }
 
 func TestInputTime(t *testing.T) {

--- a/element_test.go
+++ b/element_test.go
@@ -288,6 +288,7 @@ func TestShadowDOM(t *testing.T) {
 	elNoShadow := p.MustElement("script")
 	_, err := elNoShadow.ShadowRoot()
 	g.True((&rod.ErrNoShadowRoot{}).Is(err))
+	g.Has(err.Error(), "element has no shadow root:")
 }
 
 func TestInputTime(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -181,3 +181,16 @@ type ErrPageNotFound struct {
 func (e *ErrPageNotFound) Error() string {
 	return "cannot find page"
 }
+
+// ErrNoShadowRoot error
+type ErrNoShadowRoot struct {
+	*Element
+}
+
+// Error ...
+func (e *ErrNoShadowRoot) Error() string {
+	return fmt.Sprintf("element has no shadow root: %s", e.String())
+}
+
+// Is interface
+func (e *ErrNoShadowRoot) Is(err error) bool { _, ok := err.(*ErrNoShadowRoot); return ok }


### PR DESCRIPTION
Addresses #787 

# Development guide

[Link](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
