### PR TITLE
Add Element.Disabled() and Element.MustDisabled()

### DIFF
--- a/element.go
+++ b/element.go
@@ -365,6 +365,15 @@ func (el *Element) Property(name string) (gson.JSON, error) {
 	return prop.Value, nil
 }
 
+// Disabled checks if the element is disabled.
+func (el *Element) Disabled() (bool, error) {
+	prop, err := el.Property("disabled")
+	if err != nil {
+		return false, err
+	}
+	return prop.Bool(), nil
+}
+
 // SetFiles of the current file input element
 func (el *Element) SetFiles(paths []string) error {
 	absPaths := utils.AbsolutePaths(paths)

--- a/element_test.go
+++ b/element_test.go
@@ -490,6 +490,21 @@ func TestProperty(t *testing.T) {
 	})
 }
 
+func TestDisabled(t *testing.T) {
+	g := setup(t)
+
+	p := g.page.MustNavigate(g.srcFile("fixtures/input.html"))
+
+	g.False(p.MustElement("#EnabledButton").MustDisabled())
+	g.True(p.MustElement("#DisabledButton").MustDisabled())
+
+	g.Panic(func() {
+		el := p.MustElement("#EnabledButton")
+		g.mc.stubErr(1, proto.RuntimeCallFunctionOn{})
+		el.MustDisabled()
+	})
+}
+
 func TestSetFiles(t *testing.T) {
 	g := setup(t)
 

--- a/fixtures/input.html
+++ b/fixtures/input.html
@@ -66,6 +66,14 @@
 
       <hr />
 
+      <button type="button" id="EnabledButton">Enabled Button</button>
+
+      <button type="button" id="DisabledButton" disabled>
+        Disabled Button
+      </button>
+
+      <hr />
+
       <input type="submit" value="submit" />
     </form>
   </body>

--- a/must.go
+++ b/must.go
@@ -834,6 +834,13 @@ func (el *Element) MustProperty(name string) gson.JSON {
 	return prop
 }
 
+// MustDisabled is similar to Element.Disabled
+func (el *Element) MustDisabled() bool {
+	disabled, err := el.Disabled()
+	el.e(err)
+	return disabled
+}
+
 // MustContainsElement is similar to Element.ContainsElement
 func (el *Element) MustContainsElement(target *Element) bool {
 	contains, err := el.ContainsElement(target)


### PR DESCRIPTION
# Overview
This change allows users to check if an element is disabled. More information about the disabled attribute can be found at:
  https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled

Similar methods already exist in other browser automation frameworks. For example, Playwright has `elementHandle.isDisabled()`:
 https://playwright.dev/docs/api/class-elementhandle#element-handle-is-disabled

This commit is based on discussions in #798

# Testing

- Unit test `go test -run ^TestDisabled$` passes.
- Code coverage remains at 100% 
- General tests `go test` fail with one error which appears to be unrelated to this change:
```shell
$ go test
parallel test 8
--- FAIL: TestBinarySize (2.67s)
    browser_test.go:287: 10.515625 ⦗not ≤⦘ 10.5
FAIL
exit status 1
FAIL	github.com/go-rod/rod	29.786s
```
