### PR TITLE
feat: rewrite waitNavigation func

### DIFF
--- a/input_test.go
+++ b/input_test.go
@@ -1,6 +1,9 @@
 package rod_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-rod/rod/lib/devices"
@@ -261,7 +264,15 @@ func TestTouch(t *testing.T) {
 
 	wait := page.WaitNavigation(proto.PageLifecycleEventNameLoad)
 	page.MustNavigate(g.srcFile("fixtures/touch.html"))
-	wait()
+	err := wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 
 	touch := page.Touch
 

--- a/must.go
+++ b/must.go
@@ -397,7 +397,7 @@ func (p *Page) MustWaitOpen() (wait func() (newPage *Page)) {
 }
 
 // MustWaitNavigation is similar to Page.WaitNavigation
-func (p *Page) MustWaitNavigation() func() {
+func (p *Page) MustWaitNavigation() func() error {
 	return p.WaitNavigation(proto.PageLifecycleEventNameNetworkAlmostIdle)
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -3,6 +3,8 @@ package rod_test
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"image/png"
 	"math"
 	"net/http"
@@ -441,7 +443,15 @@ func TestPageWaitNavigation(t *testing.T) {
 	s := g.Serve().Route("/", "")
 	wait := g.page.MustWaitNavigation()
 	g.page.MustNavigate(s.URL())
-	wait()
+	err := wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 }
 
 func TestPageWaitRequestIdle(t *testing.T) {
@@ -783,20 +793,52 @@ func TestPageNavigation(t *testing.T) {
 
 	wait := p.WaitNavigation(proto.PageLifecycleEventNameDOMContentLoaded)
 	p.MustNavigate(g.srcFile("fixtures/click.html"))
-	wait()
+	err := wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 
 	wait = p.WaitNavigation(proto.PageLifecycleEventNameDOMContentLoaded)
 	p.MustNavigate(g.srcFile("fixtures/selector.html"))
-	wait()
+	err = wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 
 	wait = p.WaitNavigation(proto.PageLifecycleEventNameDOMContentLoaded)
 	p.MustNavigateBack()
-	wait()
+	err = wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 	g.Regex("fixtures/click.html$", p.MustInfo().URL)
 
 	wait = p.WaitNavigation(proto.PageLifecycleEventNameDOMContentLoaded)
 	p.MustNavigateForward()
-	wait()
+	err = wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 	g.Regex("fixtures/selector.html$", p.MustInfo().URL)
 
 	g.mc.stubErr(1, proto.RuntimeCallFunctionOn{})
@@ -829,7 +871,15 @@ func TestPageElementFromObjectErr(t *testing.T) {
 	p := g.newPage()
 	wait := p.WaitNavigation(proto.PageLifecycleEventNameLoad)
 	p.MustNavigate(g.srcFile("./fixtures/click.html"))
-	wait()
+	err := wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			fmt.Println("wait is canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Println("wait is timeout")
+		}
+	}
 	res, err := proto.DOMGetNodeForLocation{X: 10, Y: 10}.Call(p)
 	g.E(err)
 


### PR DESCRIPTION
make `wait` func return error used to judge timeout,canceled etc.
