### PR TITLE
Add OpenBSD for `LookPath' function.

### DIFF
--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -333,6 +333,10 @@ func LookPath() (found string, has bool) {
 			"/snap/bin/chromium",
 			"/data/data/com.termux/files/usr/bin/chromium-browser",
 		},
+		"openbsd": {
+			"chrome",
+			"chromium",
+		},
 		"windows": append([]string{"chrome", "edge"}, expandWindowsExePaths(
 			`Google\Chrome\Application\chrome.exe`,
 			`Chromium\Application\chrome.exe`,


### PR DESCRIPTION
Hi, Nuclei's Headless feature relies on the go-rod library and looks for Chrome executables via the LookPath function, but it could not be found in OpenBSD, so I added the patch.

The following is some of the information in OpenBSD:

```
$ cat hi.go                                                                                                                                                                                            
package main

import (
	"fmt"
	"runtime"
)

func main() {
	fmt.Println(runtime.GOOS)
}
$ go run hi.go 
openbsd
$ whereis chrome
/usr/local/bin/chrome
$ uname -a
OpenBSD my-openbsd 7.3 GENERIC.MP#1125 amd64
```