### PR TITLE
Fix bug with not setting Sec-WebSocket-Key header.

### DIFF
--- a/lib/cdp/websocket.go
+++ b/lib/cdp/websocket.go
@@ -209,6 +209,7 @@ func (ws *WebSocket) handshake(ctx context.Context, u *url.URL, header http.Head
 			req.Host = vs[0]
 		} else if k == "Sec-WebSocket-Key" && len(vs) > 0 {
 			secKey = vs[0]
+			req.Header[k] = vs
 		} else {
 			req.Header[k] = vs
 		}


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

Sorry, made a bug in previous PR.