### PR TITLE
Avoid panicking if a bad regexp is returned after converting glob pattern to regexp

### DIFF
--- a/hijack.go
+++ b/hijack.go
@@ -117,7 +117,10 @@ func (r *HijackRouter) Add(pattern string, resourceType proto.NetworkResourceTyp
 		ResourceType: resourceType,
 	})
 
-	reg := regexp.MustCompile(proto.PatternToReg(pattern))
+	reg, err := regexp.Compile(proto.PatternToReg(pattern))
+	if err != nil {
+		return err
+	}
 
 	r.handlers = append(r.handlers, &hijackHandler{
 		pattern: pattern,


### PR DESCRIPTION
Fixes #982 

# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
