### PR TITLE
Add PagePool.MustGet, modify Get method allow error return rather recover panic.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -582,7 +582,7 @@ func ExamplePage_pool() {
 	}
 
 	yourJob := func() {
-		page := pool.Get(create)
+		page := pool.MustGet(create)
 
 		// Put the instance back to the pool after we're done,
 		// so the instance can be reused by other goroutines.

--- a/lib/examples/use-rod-like-chrome-extension/main.go
+++ b/lib/examples/use-rod-like-chrome-extension/main.go
@@ -51,7 +51,7 @@ func linkPreviewer(browser *rod.Browser) {
 
 		// Expose a function to the page to provide preview
 		page.MustExpose("getPreview", func(url gson.JSON) (interface{}, error) {
-			p := pool.Get(create)
+			p := pool.MustGet(create)
 			defer pool.Put(p)
 			p.MustNavigate(url.Str())
 			return base64.StdEncoding.EncodeToString(p.MustScreenshot()), nil


### PR DESCRIPTION
# PagePool 

The `PagePool.Get` can now only accept `create func() *Page` as input, so there is no way to output the error that may exist in the create func other than using a closure, and it is inconvenient for users in a multi-routine environment to perform logical processing based on the actual error that occurred.

However, I'm not sure whether this change would be in line with the original design.

By the way, `PagePool.CleanUp` may stuck while `pp` is not full. I also think this might be an issue when using **PagePool**.