### PR TITLE
Feat: change the PagePool.Get method so that it returns an error for processing.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -582,7 +582,7 @@ func ExamplePage_pool() {
 	}
 
 	yourJob := func() {
-		page := pool.Get(create)
+		page := pool.MustGet(create)
 
 		// Put the instance back to the pool after we're done,
 		// so the instance can be reused by other goroutines.

--- a/lib/examples/use-rod-like-chrome-extension/main.go
+++ b/lib/examples/use-rod-like-chrome-extension/main.go
@@ -51,7 +51,7 @@ func linkPreviewer(browser *rod.Browser) {
 
 		// Expose a function to the page to provide preview
 		page.MustExpose("getPreview", func(url gson.JSON) (interface{}, error) {
-			p := pool.Get(create)
+			p := pool.MustGet(create)
 			defer pool.Put(p)
 			p.MustNavigate(url.Str())
 			return base64.StdEncoding.EncodeToString(p.MustScreenshot()), nil

--- a/must.go
+++ b/must.go
@@ -1155,3 +1155,12 @@ func (el *Element) MustGetXPath(optimized bool) string {
 	el.e(err)
 	return xpath
 }
+
+// MustGet a page from the pool. Use the [PagePool.Put] to make it reusable later.
+func (pp PagePool) MustGet(create func() *Page) *Page {
+	p := <-pp
+	if p == nil {
+		p = create()
+	}
+	return p
+}

--- a/utils.go
+++ b/utils.go
@@ -92,15 +92,6 @@ func NewPagePool(limit int) PagePool {
 	return pp
 }
 
-// MustGet a page from the pool. Use the [PagePool.Put] to make it reusable later.
-func (pp PagePool) MustGet(create func() *Page) *Page {
-	p := <-pp
-	if p == nil {
-		p = create()
-	}
-	return p
-}
-
 // Get a page from the pool, allow error. Use the [PagePool.Put] to make it reusable later.
 func (pp PagePool) Get(create func() (*Page, error)) (*Page, error) {
 	p := <-pp

--- a/utils.go
+++ b/utils.go
@@ -110,12 +110,15 @@ func (pp PagePool) Put(p *Page) {
 	pp <- p
 }
 
-// Cleanup helper, may stuck while PagePool is not full
+// Cleanup helper
 func (pp PagePool) Cleanup(iteratee func(*Page)) {
 	for i := 0; i < cap(pp); i++ {
-		p := <-pp
-		if p != nil {
-			iteratee(p)
+		select {
+		case p := <-pp:
+			if p != nil {
+				iteratee(p)
+			}
+		default:
 		}
 	}
 }


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

## PagePool Change

- PagePool changes the Get method so that it returns an error for processing
- Add MustGet to be compatible with previous Get
- Modify CleanUp method to prevent stucking

The `PagePool.Get` can now only accept `create func() *Page` as input, so there is no way to output the error that may exist in the create func other than using a closure or using recover, and it is inconvenient for users in a multi-routine environment to perform logical processing based on the actual error that occurred.

_However, I'm not sure whether this change would be in line with the original design._

`PagePool.CleanUp` may stuck while `pp` is not full. I also think this might be an issue when using **PagePool**. Use `select` to prevent stucking
