### PR TITLE
Feat: Add the PagePool.TryGet method while it returns an error for processing. 

### DIFF
--- a/browser_test.go
+++ b/browser_test.go
@@ -443,7 +443,7 @@ func TestBrowserConnectFailure(t *testing.T) {
 func TestBrowserPool(_ *testing.T) {
 	pool := rod.NewBrowserPool(3)
 	create := func() *rod.Browser { return rod.New().MustConnect() }
-	b := pool.Get(create)
+	b := pool.MustGet(create)
 	pool.Put(b)
 	pool.Cleanup(func(p *rod.Browser) {
 		p.MustClose()
@@ -464,7 +464,7 @@ func TestBrowserPool_TryGet(t *testing.T) {
 		return b, err
 	}
 	for i := 0; i < 4; i++ {
-		b, err := pool.TryGet(create)
+		b, err := pool.Get(create)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -486,13 +486,13 @@ func TestBrowserPool_TryGet_Negative(t *testing.T) {
 		err := b.Connect()
 		return b, err
 	}
-	b, err := pool.TryGet(create)
+	b, err := pool.Get(create)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pool.Put(b)
 	cancel()
-	b, err = pool.TryGet(create)
+	b, err = pool.Get(create)
 	if err != nil {
 		t.Log(err)
 	} else {

--- a/browser_test.go
+++ b/browser_test.go
@@ -497,6 +497,7 @@ func TestBrowserPool_TryGet_Negative(t *testing.T) {
 		t.Log(err)
 		return
 	} else {
+		pool.Put(b)
 		t.FailNow()
 	}
 }

--- a/browser_test.go
+++ b/browser_test.go
@@ -449,6 +449,23 @@ func TestBrowserPool(_ *testing.T) {
 	})
 }
 
+func TestBrowserPool_TryGet(t *testing.T) {
+	pool := rod.NewBrowserPool(3)
+	create := func() (*rod.Browser, error) {
+		b := rod.New()
+		err := b.Connect()
+		return b, err
+	}
+	b, err := pool.TryGet(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.Put(b)
+	pool.Cleanup(func(p *rod.Browser) {
+		p.MustClose()
+	})
+}
+
 func TestOldBrowser(t *testing.T) {
 	t.Skip()
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -495,7 +495,6 @@ func TestBrowserPool_TryGet_Negative(t *testing.T) {
 	b, err = pool.TryGet(create)
 	if err != nil {
 		t.Log(err)
-		return
 	} else {
 		pool.Put(b)
 		t.FailNow()

--- a/examples_test.go
+++ b/examples_test.go
@@ -582,7 +582,7 @@ func ExamplePage_pool() {
 	}
 
 	yourJob := func() {
-		page := pool.Get(create)
+		page := pool.MustGet(create)
 
 		// Put the instance back to the pool after we're done,
 		// so the instance can be reused by other goroutines.
@@ -632,7 +632,7 @@ func ExampleBrowser_pool() {
 			defer wg.Done()
 
 			// Get a browser instance from the pool
-			browser := pool.Get(create)
+			browser := pool.MustGet(create)
 
 			// Put the instance back to the pool after we're done,
 			// so the instance can be reused by other goroutines.

--- a/lib/examples/use-rod-like-chrome-extension/main.go
+++ b/lib/examples/use-rod-like-chrome-extension/main.go
@@ -51,7 +51,7 @@ func linkPreviewer(browser *rod.Browser) {
 
 		// Expose a function to the page to provide preview
 		page.MustExpose("getPreview", func(url gson.JSON) (interface{}, error) {
-			p := pool.Get(create)
+			p := pool.MustGet(create)
 			defer pool.Put(p)
 			p.MustNavigate(url.Str())
 			return base64.StdEncoding.EncodeToString(p.MustScreenshot()), nil

--- a/must.go
+++ b/must.go
@@ -1155,3 +1155,21 @@ func (el *Element) MustGetXPath(optimized bool) string {
 	el.e(err)
 	return xpath
 }
+
+// MustGet a page from the pool. Use the [PagePool.Put] to make it reusable later.
+func (pp PagePool) MustGet(create func() *Page) *Page {
+	p := <-pp
+	if p == nil {
+		p = create()
+	}
+	return p
+}
+
+// MustGet a browser from the pool. Use the [BrowserPool.Put] to make it reusable later.
+func (bp BrowserPool) MustGet(create func() *Browser) *Browser {
+	p := <-bp
+	if p == nil {
+		p = create()
+	}
+	return p
+}

--- a/page_test.go
+++ b/page_test.go
@@ -978,14 +978,14 @@ func TestPagePool(t *testing.T) {
 
 	pool := rod.NewPagePool(3)
 	create := func() *rod.Page { return g.browser.MustPage() }
-	p := pool.Get(create)
+	p := pool.MustGet(create)
 	pool.Put(p)
 	pool.Cleanup(func(p *rod.Page) {
 		p.MustClose()
 	})
 }
 
-func TestPagePool_TryGet(t *testing.T) {
+func TestPagePool_Get(t *testing.T) {
 	g := setup(t)
 
 	pool := rod.NewPagePool(3)
@@ -1000,7 +1000,7 @@ func TestPagePool_TryGet(t *testing.T) {
 		return b.Page(proto.TargetCreateTarget{URL: ""})
 	}
 	for i := 0; i < 4; i++ {
-		p, err := pool.TryGet(create)
+		p, err := pool.Get(create)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1008,7 +1008,7 @@ func TestPagePool_TryGet(t *testing.T) {
 	}
 }
 
-func TestPagePool_TryGet_Negative(t *testing.T) {
+func TestPagePool_Get_Negative(t *testing.T) {
 	g := setup(t)
 	failContext, cancel := context.WithCancel(g.Context())
 	g.browser = g.browser.Context(failContext)
@@ -1029,14 +1029,14 @@ func TestPagePool_TryGet_Negative(t *testing.T) {
 		}
 		return b.Page(proto.TargetCreateTarget{URL: ""})
 	}
-	p, err := pool.TryGet(create)
+	p, err := pool.Get(create)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pool.Put(p)
 
 	cancel()
-	p, err = pool.TryGet(create)
+	p, err = pool.Get(create)
 	if err != nil {
 		t.Log(err)
 	} else {

--- a/page_test.go
+++ b/page_test.go
@@ -985,6 +985,64 @@ func TestPagePool(t *testing.T) {
 	})
 }
 
+func TestPagePool_TryGet(t *testing.T) {
+	g := setup(t)
+
+	pool := rod.NewPagePool(3)
+	defer pool.Cleanup(func(p *rod.Page) {
+		p.MustClose()
+	})
+	create := func() (*rod.Page, error) {
+		b, err := g.browser.Incognito()
+		if err != nil {
+			return nil, err
+		}
+		return b.Page(proto.TargetCreateTarget{URL: ""})
+	}
+	p, err := pool.TryGet(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.Put(p)
+}
+
+func TestPagePool_TryGet_Negative(t *testing.T) {
+	g := setup(t)
+	failContext, cancel := context.WithCancel(g.Context())
+	g.browser = g.browser.Context(failContext)
+	// manipulate browser canceled by another thread
+	pool := rod.NewPagePool(3)
+
+	defer pool.Cleanup(func(p *rod.Page) {
+		err := p.Close()
+		if err != nil {
+			t.Log(err)
+		}
+	})
+
+	create := func() (*rod.Page, error) {
+		b, err := g.browser.Incognito()
+		if err != nil {
+			return nil, err
+		}
+		return b.Page(proto.TargetCreateTarget{URL: ""})
+	}
+	p, err := pool.TryGet(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.Put(p)
+
+	cancel()
+	p, err = pool.TryGet(create)
+	if err != nil {
+		t.Log(err)
+	} else {
+		pool.Put(p)
+		t.FailNow()
+	}
+}
+
 func TestPageUseNonExistSession(t *testing.T) {
 	g := setup(t)
 

--- a/page_test.go
+++ b/page_test.go
@@ -999,11 +999,13 @@ func TestPagePool_TryGet(t *testing.T) {
 		}
 		return b.Page(proto.TargetCreateTarget{URL: ""})
 	}
-	p, err := pool.TryGet(create)
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 4; i++ {
+		p, err := pool.TryGet(create)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pool.Put(p)
 	}
-	pool.Put(p)
 }
 
 func TestPagePool_TryGet_Negative(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -92,17 +92,8 @@ func NewPagePool(limit int) PagePool {
 	return pp
 }
 
-// Get a page from the pool. Use the [PagePool.Put] to make it reusable later.
-func (pp PagePool) Get(create func() *Page) *Page {
-	p := <-pp
-	if p == nil {
-		p = create()
-	}
-	return p
-}
-
-// TryGet a page from the pool, allow error. Use the [PagePool.Put] to make it reusable later.
-func (pp PagePool) TryGet(create func() (*Page, error)) (*Page, error) {
+// Get a page from the pool, allow error. Use the [PagePool.Put] to make it reusable later.
+func (pp PagePool) Get(create func() (*Page, error)) (*Page, error) {
 	p := <-pp
 	if p == nil {
 		return create()
@@ -143,17 +134,8 @@ func NewBrowserPool(limit int) BrowserPool {
 	return pp
 }
 
-// Get a browser from the pool. Use the [BrowserPool.Put] to make it reusable later.
-func (bp BrowserPool) Get(create func() *Browser) *Browser {
-	p := <-bp
-	if p == nil {
-		p = create()
-	}
-	return p
-}
-
-// TryGet a browser from the pool, allow error. Use the [BrowserPool.Put] to make it reusable later.
-func (bp BrowserPool) TryGet(create func() (*Browser, error)) (*Browser, error) {
+// Get a browser from the pool, allow error. Use the [BrowserPool.Put] to make it reusable later.
+func (bp BrowserPool) Get(create func() (*Browser, error)) (*Browser, error) {
 	p := <-bp
 	if p == nil {
 		return create()

--- a/utils.go
+++ b/utils.go
@@ -104,12 +104,8 @@ func (pp PagePool) Get(create func() *Page) *Page {
 // TryGet a page from the pool, allow error. Use the [PagePool.Put] to make it reusable later.
 func (pp PagePool) TryGet(create func() (*Page, error)) (*Page, error) {
 	p := <-pp
-	var err error
 	if p == nil {
-		p, err = create()
-		if err != nil {
-			return nil, err
-		}
+		return create()
 	}
 	return p, nil
 }


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
## PagePool Change

- PagePool/BrowserPool Add the MustGet method to replace Get, and Get returns an error for processing
- Modify CleanUp method to prevent stucking

The `PagePool.Get` can now only accept `create func() *Page` as input, so there is no way to output the error that may exist in the create func other than using a closure or using recover, and it is inconvenient for users in a multi-routine environment to perform logical processing based on the actual error that occurred. I added the `PagePool.MustGet` method to solve this. _However, I'm not sure whether this change would be in line with the original design._

Besides, `PagePool.CleanUp` may stuck while `pp` is not full (forget/panic to Put, etc). I also think this might be an issue when using **PagePool**. Use `select` to prevent stucking