### PR TITLE
feat: add support for Page.ResetNavigationHistory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ tmp/
 *.out
 *.test
 *.json
-/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/
 *.out
 *.test
 *.json
+/.idea

--- a/must.go
+++ b/must.go
@@ -233,6 +233,12 @@ func (p *Page) MustNavigate(url string) *Page {
 	return p
 }
 
+// MustResetNavigationHistory is similar to [Page.ResetNavigationHistory]
+func (p *Page) MustResetNavigationHistory() *Page {
+	p.e(p.ResetNavigationHistory())
+	return p
+}
+
 // MustReload is similar to [Page.Reload].
 func (p *Page) MustReload() *Page {
 	p.e(p.Reload())

--- a/page.go
+++ b/page.go
@@ -1027,7 +1027,7 @@ func (p *Page) Event() <-chan *Message {
 				select {
 				case <-p.ctx.Done():
 					return
-				case dst <- msg.(*Message): // nolint: forcetypeassert
+				case dst <- msg.(*Message): //nolint: forcetypeassert
 				}
 			}
 		}

--- a/page.go
+++ b/page.go
@@ -197,6 +197,17 @@ func (p *Page) NavigateBack() error {
 	return err
 }
 
+// ResetNavigationHistory reset history
+func (p *Page) ResetNavigationHistory() error {
+	err := proto.PageResetNavigationHistory{}.Call(p)
+	return err
+}
+
+// GetNavigationHistory get navigation history
+func (p *Page) GetNavigationHistory() (*proto.PageGetNavigationHistoryResult, error) {
+	return proto.PageGetNavigationHistory{}.Call(p)
+}
+
 // NavigateForward history.
 func (p *Page) NavigateForward() error {
 	// Not using cdp API because it doesn't work for iframe
@@ -1016,7 +1027,7 @@ func (p *Page) Event() <-chan *Message {
 				select {
 				case <-p.ctx.Done():
 					return
-				case dst <- msg.(*Message): //nolint: forcetypeassert
+				case dst <- msg.(*Message): // nolint: forcetypeassert
 				}
 			}
 		}


### PR DESCRIPTION
# Add ResetNavigationHistory functionality

## Description

This PR adds a new function `ResetNavigationHistory` to the `Page` struct, along with its `Must` variant `MustResetNavigationHistory`. This feature allows users to clear the navigation history of a page, which is particularly useful when pages are reused in a pool.

## Changes

1. Added `ResetNavigationHistory` method to `Page` struct in `page.go`
2. Added `MustResetNavigationHistory` method to `Page` struct in `must.go`
3. Added a new test function `TestPageResetNavigationHistory` in `page_test.go`

## Motivation

When pages are reused in a pool, the navigation history accumulates over time. This can lead to unexpected behavior and potentially impact performance. The ability to reset the navigation history provides more control over the page state, especially in scenarios where a clean slate is desired for each new use of a pooled page.


## Usage
Users can now reset the navigation history of a page like this:

```golang
err := page.ResetNavigationHistory()
```

Or using the Must variant:

```golang
page.MustResetNavigationHistory()
```