### PR TITLE
opt: formatToJSFunc use string plus

### DIFF
--- a/page_eval.go
+++ b/page_eval.go
@@ -111,7 +111,7 @@ func (e *EvalOptions) ByPromise() *EvalOptions {
 
 func (e *EvalOptions) formatToJSFunc() string {
 	js := strings.Trim(e.JS, "\t\n\v\f\r ;")
-	return fmt.Sprintf(`function() { return (%s).apply(this, arguments) }`, js)
+	return `function() { return (` + js + `).apply(this, arguments) }`
 }
 
 // Eval is a shortcut for [Page.Evaluate] with AwaitPromise, ByValue set to true.


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

when I  use pprof analyze  memory , I found this : 
<img width="723" alt="image" src="https://github.com/user-attachments/assets/551bc22a-85f5-4b39-95bd-03b43e4324a6">
so, I use string plus instead fmt.Sprintf