### PR TITLE
Update defaults.go

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -147,7 +147,9 @@ func init() {
 func ResetWith(options string) {
 	Reset()
 
-	if _, has := os.LookupEnv("DISABLE_ROD_FLAG"); !has {
+	if rodFlags, has := os.LookupEnv("ROD_FLAGS"); has {
+		options = rodFlags
+	} else if _, has := os.LookupEnv("DISABLE_ROD_FLAG"); !has {
 		if !flag.Parsed() && flag.Lookup("rod") == nil {
 			flag.String("rod", "", `Set the default value of options used by rod.`)
 		}


### PR DESCRIPTION
enable env var ROD_FLAGS that works the same as -rod flags from cmd line

# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
