### PR TITLE
Close pool in Cleanup to prevent Get getting stuck in concurrent scenarios.

### DIFF
--- a/browser_test.go
+++ b/browser_test.go
@@ -460,6 +460,27 @@ func TestBrowserPool(t *testing.T) {
 	})
 }
 
+func TestBrowserPoolNotStuck(t *testing.T) {
+	g := got.T(t)
+
+	pool := rod.NewBrowserPool(3)
+
+	pool.Cleanup(func(p *rod.Browser) {
+		p.MustClose()
+	})
+
+	b, err := pool.Get(func() (*rod.Browser, error) {
+		browser := rod.New()
+		return browser, browser.Connect()
+	})
+	if err != nil {
+		g.Equal(err, errors.New("pool has been cleaned up"))
+	} else {
+		pool.Put(b) // will panic
+		g.Fail()
+	}
+}
+
 func TestOldBrowser(t *testing.T) {
 	t.Skip()
 

--- a/page_test.go
+++ b/page_test.go
@@ -992,6 +992,25 @@ func TestPagePool(t *testing.T) {
 	})
 }
 
+func TestPagePoolNotStuck(t *testing.T) {
+	g := setup(t)
+	pool := rod.NewPagePool(3)
+
+	pool.Cleanup(func(p *rod.Page) {
+		p.MustClose()
+	})
+
+	b, err := pool.Get(func() (*rod.Page, error) {
+		return g.browser.Page(proto.TargetCreateTarget{})
+	})
+	if err != nil {
+		g.Equal(err, errors.New("pool has been cleaned up"))
+	} else {
+		pool.Put(b) // will panic
+		g.Fail()
+	}
+}
+
 func TestPageUseNonExistSession(t *testing.T) {
 	g := setup(t)
 


### PR DESCRIPTION
Close pool in Cleanup to prevent Get getting stuck in concurrent scenarios.

# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```


