### PR TITLE
SetHeader should replace entries with the same key

### DIFF
--- a/hijack.go
+++ b/hijack.go
@@ -356,11 +356,24 @@ func (ctx *HijackResponse) Headers() http.Header {
 
 // SetHeader of the payload via key-value pairs.
 func (ctx *HijackResponse) SetHeader(pairs ...string) *HijackResponse {
+	headerIndex := make(map[string]int, len(ctx.payload.ResponseHeaders))
+	for i, header := range ctx.payload.ResponseHeaders {
+		headerIndex[header.Name] = i
+	}
+
 	for i := 0; i < len(pairs); i += 2 {
-		ctx.payload.ResponseHeaders = append(ctx.payload.ResponseHeaders, &proto.FetchHeaderEntry{
-			Name:  pairs[i],
-			Value: pairs[i+1],
-		})
+		name := pairs[i]
+		value := pairs[i+1]
+
+		if idx, exists := headerIndex[name]; exists {
+			ctx.payload.ResponseHeaders[idx].Value = value
+		} else {
+			ctx.payload.ResponseHeaders = append(ctx.payload.ResponseHeaders, &proto.FetchHeaderEntry{
+				Name:  name,
+				Value: value,
+			})
+			headerIndex[name] = len(ctx.payload.ResponseHeaders) - 1
+		}
 	}
 	return ctx
 }

--- a/hijack.go
+++ b/hijack.go
@@ -378,6 +378,18 @@ func (ctx *HijackResponse) SetHeader(pairs ...string) *HijackResponse {
 	return ctx
 }
 
+// Append key-value pairs to the end of the response headers.
+// Duplicate keys will be preserved.
+func (ctx *HijackResponse) AddHeader(pairs ...string) *HijackResponse {
+	for i := 0; i < len(pairs); i += 2 {
+		ctx.payload.ResponseHeaders = append(ctx.payload.ResponseHeaders, &proto.FetchHeaderEntry{
+			Name:  pairs[i],
+			Value: pairs[i+1],
+		})
+	}
+	return ctx
+}
+
 // SetBody of the payload, if obj is []byte or string, raw body will be used, else it will be encoded as json.
 func (ctx *HijackResponse) SetBody(obj interface{}) *HijackResponse {
 	switch body := obj.(type) {

--- a/hijack.go
+++ b/hijack.go
@@ -378,7 +378,7 @@ func (ctx *HijackResponse) SetHeader(pairs ...string) *HijackResponse {
 	return ctx
 }
 
-// Append key-value pairs to the end of the response headers.
+// AddHeader appends key-value pairs to the end of the response headers.
 // Duplicate keys will be preserved.
 func (ctx *HijackResponse) AddHeader(pairs ...string) *HijackResponse {
 	for i := 0; i < len(pairs); i += 2 {

--- a/hijack_test.go
+++ b/hijack_test.go
@@ -75,6 +75,8 @@ func TestHijack(t *testing.T) {
 		g.Has(ctx.Response.Headers().Get("Content-Type"), "text/html; charset=utf-8")
 
 		// override response header
+		ctx.Response.AddHeader("Set-Cookie", "key=val1")
+		// This should override the previous one
 		ctx.Response.SetHeader("Set-Cookie", "key=val")
 
 		// override response body


### PR DESCRIPTION
The original `SetHeader` only appends the key-value pair to the end of headers list. The name `SetHeader` is therefore misleading. 

Adding header to the end sometimes won't have the same effect as replacing the header. For example, if the original response has these headers:

```
Access-Control-Allow-Origin: https://example.com
Access-Control-Allow-Credentials: true
```

And after the following operations:

```go
h.Response.SetHeader("Access-Control-Allow-Origin", "https://example.com")
```

The browser will complain about: `The 'Access-Control-Allow-Origin' header contains multiple values 'https://example.com, https://example.com', but only one is allowed.`


This PR changes the behavior of `SetHeader` to replace the value of the header if it exists. If the header does not exist, it will be appended to the end of the headers list. 

Also, if one writes:

```go
h.Response.SetHeader(
  "My-Header", "a",
  "My-Header", "b",
)
```

Only the last value will be kept. 
