### PR TITLE
add support for google chrome on nixos

### DIFF
--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -220,6 +220,7 @@ func LookPath() (found string, has bool) {
 			"/usr/bin/microsoft-edge",
 			"chromium",
 			"chromium-browser",
+			"google-chrome-stable",
 			"/usr/bin/google-chrome-stable",
 			"/usr/bin/chromium",
 			"/usr/bin/chromium-browser",


### PR DESCRIPTION
in nixos the bin for google-chrome is installed as ```google-chrome-stable``` not ```google-chrome```

```sh
[sacs@nixos:~/Documents/browser]$ whereis google-chrome-stable 
google-chrome-stable: /nix/store/wdmrr0p6hcdw8cwzdhwihvmjmffh5ycc-user-environment/bin/google-chrome-stable
```

# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
