### PR TITLE
fix bug in WaitLoad when event has circular reference

### DIFF
--- a/fixtures/wait-load-circular-reference.html
+++ b/fixtures/wait-load-circular-reference.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <script>
+      let a = {b: 1};
+      a.c = a;
+      window.addEventListener("load", e => {
+        e.delegateTarget = a;
+      });
+    </script>
+  </head>
+  <body>
+    <iframe src="http://localhost:8080" />
+  </body>
+</html>

--- a/fixtures/wait-load-circular-reference.html
+++ b/fixtures/wait-load-circular-reference.html
@@ -1,11 +1,11 @@
 <html>
   <head>
     <script>
-      let a = {b: 1};
-      a.c = a;
-      window.addEventListener("load", e => {
-        e.delegateTarget = a;
-      });
+      let a = { b: 1 }
+      a.c = a
+      window.addEventListener('load', (e) => {
+        e.delegateTarget = a
+      })
     </script>
   </head>
   <body>

--- a/lib/js/helper.go
+++ b/lib/js/helper.go
@@ -117,7 +117,7 @@ var WaitIdle = &Function{
 // WaitLoad ...
 var WaitLoad = &Function{
 	Name:         "waitLoad",
-	Definition:   `function(){const n=this===window;return new Promise((e,t)=>{if(n){if("complete"===document.readyState)return e();window.addEventListener("load",e)}else void 0===this.complete||this.complete?e():(this.addEventListener("load",e),this.addEventListener("error",t))})}`,
+	Definition:   `function(){const n=this===window;return new Promise((e,t)=>{if(n){if("complete"===document.readyState)return e();window.addEventListener("load",_=>e())}else void 0===this.complete||this.complete?e():(this.addEventListener("load",_=>e()),this.addEventListener("error",t))})}`,
 	Dependencies: []*Function{},
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -954,15 +954,16 @@ func TestPageWaitLoadCircularReference(t *testing.T) {
 	// HTTP server lets us simulate a slow external resource which delays the
 	// page load.
 	serveMux := http.NewServeMux()
-	serveMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	serveMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(100 * time.Millisecond)
-		fmt.Fprintf(w, "Hello, World!")
+		_, err := fmt.Fprintf(w, "Hello, World!")
+		g.Err(err)
 	})
 	server := http.Server{
 		Addr:    ":8080",
 		Handler: serveMux,
 	}
-	defer server.Close()
+	defer func() { g.Err(server.Close()) }()
 
 	go func() {
 		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {

--- a/page_test.go
+++ b/page_test.go
@@ -946,6 +946,44 @@ func TestPageWaitLoadErr(t *testing.T) {
 	})
 }
 
+func TestPageWaitLoadCircularReference(t *testing.T) {
+	g := setup(t)
+
+	// We need to simulate a page taking a nontrivial amount of time to load in
+	// order to exercise the "load" event handler of js.WaitLoad. This temporary
+	// HTTP server lets us simulate a slow external resource which delays the
+	// page load.
+	serveMux := http.NewServeMux()
+	serveMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintf(w, "Hello, World!")
+	})
+	server := http.Server{
+		Addr:    ":8080",
+		Handler: serveMux,
+	}
+	defer server.Close()
+
+	go func() {
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	// Bootstrap.bundle.min.js sets up a "load" event listener and mutates the
+	// event by adding the "window" object as the delegateTarget property. If
+	// we're not careful, we might end up reading that event object from the
+	// browser as the result of the js.WaitLoad call. If the window object has a
+	// circular reference, this would cause an "Object reference chain is too
+	// long" error. Because this crash relies on event handlers firing in a
+	// specific order we need to try several times in order to have a good shot
+	// at reproducing it.
+	file := g.srcFile("fixtures/wait-load-circular-reference.html")
+	g.page.MustNavigate(file).MustWaitLoad()
+	g.page.MustNavigate(file).MustWaitLoad()
+	g.page.MustNavigate(file).MustWaitLoad()
+}
+
 func TestPageNavigation(t *testing.T) {
 	g := setup(t)
 


### PR DESCRIPTION
This fixes a bug in WaitLoad that causes it to fail with "Object reference chain is too long". This happens when we take the branch of the [WaitLoad js](https://github.com/15joeybloom/rod/blob/10bc1168d4fb6e00edd490da96623aa72a6312ff/lib/js/helper.go#L120) that listens for the "load" event. In this case the load event object is returned by the function, and the object's value is loaded from the browser by rod. Sometimes this object can have a circular reference, causing the CDP to throw the Object reference chain is too long error. 

I have seen the event object have a circular reference on sites using bootstrap.bundle.min.js. That library adds a `delegateTarget` property to event objects. The way it does this is by mutating the event object in a "load" event handler, so delegateTarget may not always be added to the event object received by other "load" event listeners depending on the order in which the handlers fire. I set up an example site that shows the issue - here is a small script to hit the site over and over until the issue occurs. It usually only takes two tries for me to reproduce the issue.

```
package main

import (
	"github.com/go-rod/rod"
)

func main() {
	browser := rod.New().MustConnect()
	defer browser.MustClose()

	page := browser.MustPage()

	for {
		page.MustNavigate("https://joeysandbox.weebly.com")
		page.MustWaitLoad()
	}
}
```

The fix was very simple - just stop returning the event object from WaitLoad, because it's not necessary.

I added a unit test, but given the complex and timing-dependent nature of the bug, the test ended up being pretty complicated. And it's still not 100% robust as ultimately it depends on the firing order of event handlers.

I didn't look to see whether the same bug might be possible in any of the other js functions.