### PR TITLE
feat: add wrap for window-size and window-position flag

### DIFF
--- a/lib/launcher/flags/flags.go
+++ b/lib/launcher/flags/flags.go
@@ -27,6 +27,12 @@ const (
 	// ProxyServer flag.
 	ProxyServer Flag = "proxy-server"
 
+	// WindowSize flag.
+	WindowSize Flag = "window-size"
+
+	// WindowPosition flag.
+	WindowPosition Flag = "window-position"
+
 	// WorkingDir flag.
 	WorkingDir Flag = "rod-working-dir"
 

--- a/lib/launcher/launcher.go
+++ b/lib/launcher/launcher.go
@@ -337,6 +337,16 @@ func (l *Launcher) Proxy(host string) *Launcher {
 	return l.Set(flags.ProxyServer, host)
 }
 
+// WindowSize for the browser.
+func (l *Launcher) WindowSize(x, y int) *Launcher {
+	return l.Set(flags.WindowSize, fmt.Sprintf("%d,%d", x, y))
+}
+
+// WindowPosition for the browser.
+func (l *Launcher) WindowPosition(x, y int) *Launcher {
+	return l.Set(flags.WindowPosition, fmt.Sprintf("%d,%d", x, y))
+}
+
 // WorkingDir to launch the browser process.
 func (l *Launcher) WorkingDir(path string) *Launcher {
 	return l.Set(flags.WorkingDir, path)


### PR DESCRIPTION
<img width="634" alt="image" src="https://github.com/user-attachments/assets/2e70566e-06df-4d06-9176-c4cba886c367">

https://peter.sh/experiments/chromium-command-line-switches/

Use case:

```go
l := launcher.New().HeadlessNew(false).Leakless(false)
l.WindowSize(1600, 900).WindowPosition(10, 40) // <--
u := l.MustLaunch()
defer l.Cleanup()

b := rod.New().DefaultDevice(EdgeLandscape).ControlURL(u).MustConnect()
defer b.Close()

p := b.MustPage()
defer b.Close()

p.MustNavigate("https://www.baidu.com")
time.Sleep(time.Hour)
// See the size and position of opened browser window
```

**Note: Only test manually in mac and windows 11**. It is necessary to turn off stage manager settings when using macOS.