### PR TITLE
Swap docstring links to MDN references so they're relevant to each method.

### DIFF
--- a/element.go
+++ b/element.go
@@ -616,14 +616,14 @@ func (el *Element) WaitVisible() error {
 }
 
 // WaitEnabled until the element is not disabled.
-// Doc for readonly: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly
+// Doc for disabled: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled
 func (el *Element) WaitEnabled() error {
 	defer el.tryTrace(TraceTypeWait, "enabled")()
 	return el.Wait(Eval(`() => !this.disabled`))
 }
 
 // WaitWritable until the element is not readonly.
-// Doc for disabled: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
+// Doc for readonly: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
 func (el *Element) WaitWritable() error {
 	defer el.tryTrace(TraceTypeWait, "writable")()
 	return el.Wait(Eval(`() => !this.readonly`))


### PR DESCRIPTION
Fyi there's linter errors when running the simple-check but it seems completely unrelated to the docstring changes so I've ignored them

# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
