### PR TITLE
fix: element screenshot is incorrect when DevicePixelRatio != 1 #1198

### DIFF
--- a/element.go
+++ b/element.go
@@ -673,7 +673,14 @@ func (el *Element) BackgroundImage() ([]byte, error) {
 
 // Screenshot of the area of the element.
 func (el *Element) Screenshot(format proto.PageCaptureScreenshotFormat, quality int) ([]byte, error) {
-	err := el.ScrollIntoView()
+	// this value can be modified by user.
+	res, err := el.Eval(`()=>window.devicePixelRatio || 1`)
+	if err != nil {
+		return nil, err
+	}
+	scale := res.Value.Num()
+
+	err = el.ScrollIntoView()
 	if err != nil {
 		return nil, err
 	}
@@ -698,10 +705,10 @@ func (el *Element) Screenshot(format proto.PageCaptureScreenshotFormat, quality 
 
 	// TODO: proto.PageCaptureScreenshot has a Clip option, but it's buggy, so now we do in Go.
 	return utils.CropImage(bin, quality,
-		int(box.X),
-		int(box.Y),
-		int(box.Width),
-		int(box.Height),
+		int(box.X*scale),
+		int(box.Y*scale),
+		int(box.Width*scale),
+		int(box.Height*scale),
 	)
 }
 


### PR DESCRIPTION
# Development guide

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```

fix #1198

先别急同意。我在本地倒是调试过了，确实能解决问题。但是用执行 js 来确定当前的 ratio 也太不对味了。要是实在没有别的解决方案的话我到时候再补充下测试啥的吧。