### PR TITLE
chore:  update `fetchup` and `got`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/go-rod/rod
 go 1.21
 
 require (
-	github.com/ysmood/fetchup v0.2.3
+	github.com/ysmood/fetchup v0.5.2
 	github.com/ysmood/goob v0.4.0
-	github.com/ysmood/got v0.40.0
+	github.com/ysmood/got v0.41.0
 	github.com/ysmood/gotrace v0.6.0
 	github.com/ysmood/gson v0.7.3
 	github.com/ysmood/leakless v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/ysmood/fetchup v0.2.3 h1:ulX+SonA0Vma5zUFXtv52Kzip/xe7aj4vqT5AJwQ+ZQ=
-github.com/ysmood/fetchup v0.2.3/go.mod h1:xhibcRKziSvol0H1/pj33dnKrYyI2ebIvz5cOOkYGns=
+github.com/ysmood/fetchup v0.5.2 h1:P9w3OIA7RSNEEFvEmOiTq09IOu42C96PMyZ1MWd8TAs=
+github.com/ysmood/fetchup v0.5.2/go.mod h1:yCv8s8itjsCul1LGXJ1Q+8EQnZcVjfbZ4+l1zDm4StE=
 github.com/ysmood/goob v0.4.0 h1:HsxXhyLBeGzWXnqVKtmT9qM7EuVs/XOgkX7T6r1o1AQ=
 github.com/ysmood/goob v0.4.0/go.mod h1:u6yx7ZhS4Exf2MwciFr6nIM8knHQIE22lFpWHnfql18=
 github.com/ysmood/gop v0.2.0 h1:+tFrG0TWPxT6p9ZaZs+VY+opCvHU8/3Fk6BaNv6kqKg=
 github.com/ysmood/gop v0.2.0/go.mod h1:rr5z2z27oGEbyB787hpEcx4ab8cCiPnKxn0SUHt6xzk=
-github.com/ysmood/got v0.40.0 h1:ZQk1B55zIvS7zflRrkGfPDrPG3d7+JOza1ZkNxcc74Q=
-github.com/ysmood/got v0.40.0/go.mod h1:W7DdpuX6skL3NszLmAsC5hT7JAhuLZhByVzHTq874Qg=
+github.com/ysmood/got v0.41.0 h1:XiFH311ltTSGyxjeKcNvy7dzbJjjTzn6DBgK313JHBs=
+github.com/ysmood/got v0.41.0/go.mod h1:W7DdpuX6skL3NszLmAsC5hT7JAhuLZhByVzHTq874Qg=
 github.com/ysmood/gotrace v0.6.0 h1:SyI1d4jclswLhg7SWTL6os3L1WOKeNn/ZtzVQF8QmdY=
 github.com/ysmood/gotrace v0.6.0/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
 github.com/ysmood/gson v0.7.3 h1:QFkWbTH8MxyUTKPkVWAENJhxqdBa4lYTQWqZCiLG6kE=

--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -135,7 +135,7 @@ func (lc *Browser) Download() error {
 
 	dir := lc.Dir()
 
-	fu := fetchup.New(dir, us...)
+	fu := fetchup.New(us...).WithSaveTo(dir)
 	fu.Ctx = lc.Context
 	fu.Logger = lc.Logger
 	if lc.HTTPClient != nil {


### PR DESCRIPTION
This PR updates `github.com/ysmood/fetchup` and `github.com/ysmood/got` to the newest version. 

As visible in the first commit it bumped the version in go and adapted to changed APIs in `fetchup` 


# Development guide



[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR 

```bash
go run ./lib/utils/simple-check
```

The simple check script fails for changes outside of this PR so I could not run it outside of the full context. 
That being said I can try to fix them, I have some local changes to fix most surface problems. 