### PR TITLE
fix(browser): add FreeBSD support

### DIFF
--- a/lib/launcher/browser.go
+++ b/lib/launcher/browser.go
@@ -118,6 +118,7 @@ func (lc *Browser) Dir() string {
 func (lc *Browser) BinPath() string {
 	bin := map[string]string{
 		"darwin":  "Chromium.app/Contents/MacOS/Chromium",
+		"freebsd": "chrome",
 		"linux":   "chrome",
 		"windows": "chrome.exe",
 	}[runtime.GOOS]
@@ -228,6 +229,10 @@ func LookPath() (found string, has bool) {
 			"/data/data/com.termux/files/usr/bin/chromium-browser",
 		},
 		"openbsd": {
+			"chrome",
+			"chromium",
+		},
+		"freebsd": {
 			"chrome",
 			"chromium",
 		},


### PR DESCRIPTION
# Development guide

The PR aims to add FreeBSD support, in `BinPath` and `LooKPath`

[Link](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

## Test on local before making the PR

```bash
go run ./lib/utils/simple-check
```
