### PR TITLE
fix: clear per-session CDP states when a page closes

### DIFF
--- a/states.go
+++ b/states.go
@@ -116,4 +116,15 @@ func (p *Page) DisableDomain(method proto.Request) (restore func()) {
 
 func (p *Page) cleanupStates() {
 	p.browser.RemoveState(p.TargetID)
+
+	// Also drop every per-session state captured by Browser.set during the
+	// page's lifetime. Otherwise the params from each Browser.Call (e.g. the
+	// full HTML passed to Page.SetDocumentContent) live in browser.states
+	// forever, leaking memory in long-lived browsers that churn pages.
+	p.browser.states.Range(func(key, _ interface{}) bool {
+		if k, ok := key.(stateKey); ok && k.sessionID == p.SessionID {
+			p.browser.states.Delete(key)
+		}
+		return true
+	})
 }


### PR DESCRIPTION
Closes #1226.

cleanupStates() only dropped the cached \`*Page\` entry keyed by TargetID and left every per-session params struct that \`Browser.set\` had stored along the way. Those keyed-by-sessionID entries stay in \`browser.states\` until the browser itself shuts down, so any long-running rod browser that opens and closes pages slowly leaks. Page.SetDocumentContent with a big HTML body is the most visible case — the entire HTML hangs around forever.

Range the map and delete any state whose sessionID matches the closing page. sync.Map.Range is safe for concurrent Delete, and n is the number of live states (small under normal usage).

Repro from the issue (heap grew ~1 MB per page-close cycle on master, stays flat with this change):

\`\`\`go
b := rod.New().MustConnect()
defer b.MustClose()
for i := 0; i < 500; i++ {
    page := b.MustPage("about:blank")
    page.MustSetDocumentContent("<html><body>" + strings.Repeat("x", 1024*1024) + "</body></html>")
    page.MustClose()
}
runtime.GC()
\`\`\`