### PR TITLE
Avoid caching helpers for reset contexts

### DIFF
--- a/page_eval.go
+++ b/page_eval.go
@@ -317,7 +317,14 @@ func (p *Page) setHelper(jsCtxID proto.RuntimeRemoteObjectID, name string, fnID 
 	p.helpersLock.Lock()
 	defer p.helpersLock.Unlock()
 
-	p.helpers[jsCtxID][name] = fnID
+	// The JavaScript context can be reset while a helper is being created.
+	// Don't put a helper from the old context back into the cache.
+	list, ok := p.helpers[jsCtxID]
+	if !ok {
+		return
+	}
+
+	list[name] = fnID
 }
 
 // Returns the page's window object, the page can be an iframe.

--- a/page_eval_internal_test.go
+++ b/page_eval_internal_test.go
@@ -1,0 +1,55 @@
+package rod
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-rod/rod/lib/proto"
+)
+
+func TestPageSetHelperAfterContextReset(t *testing.T) {
+	ctxID := proto.RuntimeRemoteObjectID("context")
+	fnID := proto.RuntimeRemoteObjectID("function")
+
+	for _, reset := range []struct {
+		name       string
+		fn         func(*Page)
+		wantStored bool
+	}{
+		{
+			name: "all contexts",
+			fn: func(p *Page) {
+				p.helpers = nil
+			},
+		},
+		{
+			name: "one context",
+			fn: func(p *Page) {
+				delete(p.helpers, ctxID)
+			},
+		},
+		{
+			name:       "same context",
+			fn:         func(*Page) {},
+			wantStored: true,
+		},
+	} {
+		t.Run(reset.name, func(t *testing.T) {
+			p := &Page{helpersLock: &sync.Mutex{}}
+			p.getHelper(ctxID, "helper")
+
+			p.helpersLock.Lock()
+			reset.fn(p)
+			p.helpersLock.Unlock()
+
+			p.setHelper(ctxID, "helper", fnID)
+
+			p.helpersLock.Lock()
+			got := p.helpers[ctxID]["helper"]
+			p.helpersLock.Unlock()
+			if stored := got == fnID; stored != reset.wantStored {
+				t.Fatalf("helper stored = %t; want %t", stored, reset.wantStored)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- avoid writing a helper into a cache entry removed by a concurrent JavaScript context reset
- leave the stale helper uncached so the active context can ensure its own helper
- add deterministic coverage for whole-cache reset, single-context reset, and the normal unchanged-context path

Fixes #707.

## Testing

- `go test -count=20 -run TestPageSetHelperAfterContextReset .`
- `go vet ./...`
- `gofumpt -d page_eval.go page_eval_internal_test.go`
- `npx -ys -- cspell@6.31.1 --no-progress page_eval.go page_eval_internal_test.go`
- fork CI: Windows full test job passed; Go 1.18 build job passed

The fork's Linux job stopped in `go generate` because Chromium could not start with the hosted runner sandbox, and its macOS job stopped before tests with a `dyld` `LC_UUID` runner/toolchain error.