### PR TITLE
Fix/wait repaint context & it looks like the CI environment needs to be upgraded

### DIFF
--- a/element_test.go
+++ b/element_test.go
@@ -709,6 +709,17 @@ func TestWaitStableRAP(t *testing.T) {
 	g.Err(el.WaitStableRAF())
 }
 
+func TestWaitRepaintHonorsPageContext(t *testing.T) {
+	g := setup(t)
+	ctx, cancel := context.WithCancel(g.page.GetContext())
+	cancel()
+
+	err := g.page.Context(ctx).WaitRepaint()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitRepaint error = %v, want context.Canceled", err)
+	}
+}
+
 func TestCanvasToImage(t *testing.T) {
 	g := setup(t)
 

--- a/element_test.go
+++ b/element_test.go
@@ -2,6 +2,7 @@ package rod_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -717,6 +719,81 @@ func TestWaitRepaintHonorsPageContext(t *testing.T) {
 	err := g.page.Context(ctx).WaitRepaint()
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("WaitRepaint error = %v, want context.Canceled", err)
+	}
+}
+
+const waitStableRAFDemoPage = `<!doctype html>
+<style>#target { width: 80px; height: 30px; }</style>
+<button id="target">target</button>
+<script>
+let x = 0;
+function move() {
+  document.getElementById('target').style.transform = 'translateX(' + (x++) + 'px)';
+  requestAnimationFrame(move);
+}
+requestAnimationFrame(move);
+</script>`
+
+func TestWaitStableRAFOnBackgroundPageHonorsContext(t *testing.T) {
+	g := setup(t)
+	target := g.newPage(g.html(waitStableRAFDemoPage)).MustWaitLoad()
+	other := g.newPage(g.blank()).MustWaitLoad()
+	other.MustActivate()
+
+	// Freeze the hidden target so requestAnimationFrame cannot resolve. The
+	// operation must still return when its caller context expires.
+	if err := (proto.PageSetWebLifecycleState{State: proto.PageSetWebLifecycleStateStateFrozen}).Call(target); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := target.MustElement("#target").Context(ctx).WaitStableRAF()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("background WaitStableRAF error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestWaitStableRAFSurvivesFrequentActivationSwitches(t *testing.T) {
+	g := setup(t)
+	target := g.newPage(g.html(waitStableRAFDemoPage)).MustWaitLoad()
+	other := g.newPage(g.blank()).MustWaitLoad()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- target.MustElement("#target").Context(ctx).WaitStableRAF()
+	}()
+
+	done := make(chan struct{})
+	var switchers sync.WaitGroup
+	switchers.Add(1)
+	go func() {
+		defer switchers.Done()
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				_, _ = target.Activate()
+				_, _ = other.Activate()
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer func() {
+		close(done)
+		switchers.Wait()
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("WaitStableRAF during activation switches error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitStableRAF remained blocked during frequent activation switches")
 	}
 }
 

--- a/element_test.go
+++ b/element_test.go
@@ -747,9 +747,17 @@ func TestWaitStableRAFOnBackgroundPageHonorsContext(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	err := target.MustElement("#target").Context(ctx).WaitStableRAF()
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("background WaitStableRAF error = %v, want context deadline exceeded", err)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- target.MustElement("#target").Context(ctx).WaitStableRAF()
+	}()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("background WaitStableRAF error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("background WaitStableRAF remained blocked; this reproduces the pre-fix root-context regression")
 	}
 }
 

--- a/page.go
+++ b/page.go
@@ -848,7 +848,10 @@ func (p *Page) WaitIdle(timeout time.Duration) (err error) {
 // Doc: https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
 func (p *Page) WaitRepaint() error {
 	// we use root here because iframe doesn't trigger requestAnimationFrame
-	_, err := p.root.Eval(`() => new Promise(r => requestAnimationFrame(r))`)
+	// but the root evaluation must still inherit the caller's context. Otherwise
+	// Page.Context/Timeout cannot cancel this wait when the root page is hidden
+	// or keeps repainting indefinitely.
+	_, err := p.root.Context(p.ctx).Eval(`() => new Promise(r => requestAnimationFrame(r))`)
 	return err
 }
 


### PR DESCRIPTION
## Description

`WaitStableRAF` can block indefinitely when it is called on a background or frozen tab.

### Root cause

`Element.WaitStableRAF` derives a context-bound page before waiting for repaint:

```golang
page := el.page.Context(el.ctx)
```
However, Page.WaitRepaint performs the evaluation through p.root:
``` golang
p.root.Eval(`() => new Promise(r => requestAnimationFrame(r))`)
```

Page.Context creates a shallow page clone. Its root field still points to the original root page, so the caller's context is not propagated to the page that evaluates requestAnimationFrame.
When a tab is hidden, backgrounded, frozen, or continuously changing, requestAnimationFrame may be throttled or never invoked. In that case, the returned promise remains pending and the caller's timeout cannot cancel the operation.

## Fix
Preserve the caller's context when evaluating requestAnimationFrame on the root page:
```golang
p.root.Context(p.ctx).Eval(
    `() => new Promise(r => requestAnimationFrame(r))`,
)
```
This keeps the existing root-page behavior required for iframe support while ensuring that Page.Context, Page.Timeout, and cancellation remain effective.

## Tests
The following regression tests were added:
  - TestWaitRepaintHonorsPageContext
  - Verifies that a canceled page context is honored by WaitRepaint.
  - TestWaitStableRAFOnBackgroundPageHonorsContext
  - Uses an embedded demo page.
  - Moves the page to the background and freezes its lifecycle so RAF cannot resolve.
  - Verifies that WaitStableRAF returns context.DeadlineExceeded instead of blocking indefinitely.
  - TestWaitStableRAFSurvivesFrequentActivationSwitches
  - Uses an embedded page with a continuously changing element driven by requestAnimationFrame.
  - Frequently switches the active tab while WaitStableRAF is running.
  - Verifies that the operation still terminates when its context expires.
The background-tab test was also run against the previous implementation. It failed with:
background WaitStableRAF remained blocked; this reproduces the pre-fix root-context regression

With the fix applied, all targeted tests pass:
```bash
go test . -run 'TestWait(RepaintHonorsPageContext|StableRAFOnBackgroundPageHonorsContext|StableRAFSurvivesFrequentActivationSwitches)$' -count=1
The same tests also pass with the race detector:
go test -race . -run 'TestWait(RepaintHonorsPageContext|StableRAFOnBackgroundPageHonorsContext|StableRAFSurvivesFrequentActivationSwitches)$' -count=1
```

## Effect
Before this change, WaitStableRAF could remain blocked forever on a background or frozen tab, even when the caller supplied a timeout or cancellation context.
After this change, the operation reliably returns when its context expires, including while the target tab is inactive or when multiple tabs are repeatedly activated and deactivated.
